### PR TITLE
Add first adapters: std::optional, std::deque, std::list, and std::vector

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,9 @@ The combinators are available conveniently in the header: ``kitten/kitten.h``, o
 The following types are currently supported as both functors and monads:
 
 - ``std::optional<T>``
+- ``std::deque<T>``
+- ``std::list<T>``
+- ``std::vector<T>``
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,166 @@
 # kitten
+
 A simple library that introduces monad-like types to simplify composition for the modern C++ programmer
+
+## Problem description
+
+Functors and monads are mathematical entities studied in Category Theory and they have a plenty of applications in
+Software Engineering, particularly in Functional Programming (FP).
+
+Although they're fairly abstract concepts, there are many practical applications for them when we want to compose
+_effectful functions_. We can think about a effectful function as a function ``f`` that instead of returning a value of type
+``A`` it returns a value of type ``X<A>`` where ``X`` represents an effect which models an "extra information" about the computation
+done inside ``f``.
+
+For example:
+
+- A function ``f`` that can be fail to produce a value of type ``A`` might return an ``std::optional<A>``
+where ``td::optional`` is an effect that models absence of a value.
+- A function ``f`` that can return multiple values of type ``A`` might return an ``std::vector<A>`` where
+``std::vector`` is an effect that models multiple values.
+
+When we have functions ``f: A -> B`` and ``g: B -> C`` we can compose these two functions into a new functions
+``h: A -> C`` by using the usual function composition:
+
+`` h(x) = g(f(x)), A -> C``
+
+Therefore, it eliminates the intermediate steps involving ``B``.
+
+That's only possible because the co-domain ``A`` of ``f`` matches with the domain ``B`` of ``g``, i.e.
+the output of the first function can go into the input of the second function. But What happens when we have effectful
+functions involved?
+
+### Functors
+
+Now, consider ``f`` as an effectful function: ``f: A -> X<B>``, where ``X`` models some effect. We can't compose it
+``g: B -> C`` anymore, since it expects ``B`` and can't be fed with an ``X<B>``.
+
+Given that we can't do usual function composition, we need a more powerful way to do composition.
+
+We need a functor.
+
+If ``X<T>`` admits a functor for some type parameter ``T``, we can compose ``f`` and ``g`` by using ``fmap``:
+
+``fmap(X<A>, w: A -> B): X<B>``
+
+``fmap`` receives a functor ``X<A>``, a function that would do the composition with the "raw" types" ``A`` and ``B``, and
+it returns a new functor ``X<B>``. It basically unwraps ``X<A>``, feeds ``A`` into ``w``, wraps the output of ``w`` into
+an ``X<B>``, and then finally returns it.
+
+To do, we could do:
+
+``fmap(f(), g)``
+
+### Monads
+
+What happens if the not only ``f`` is an effectul function ``f: A -> X<B>``, but also ``g`` is ``g: B -> X<C>``. How can
+we compose ``f`` and ``g``?
+
+If we use ``fmap`` as we did before, we would end up with a return type ``X<X<B>>``, that nests the same effect. This type
+would then need to be flattened, or collapsed, into an ``X<B>``, we need a structure that knows how to flat the effects.
+
+We need a structure more powerful than a functor, we need a monad.
+
+If ``X<T>`` admits a monad for some type parameter ``T``, we can compose ``f`` and ``g`` by using ``bind``:
+
+``bind(X<A>, w: A -> X<B>): X<B>``
+
+``bind`` receives a monad ``X<A>``, a function that would do the composition with the types ``A`` and
+``X<B>``, and it returns a new monad ``X<B>``. It basically unwraps ``X<A>``, feeds ``A`` into ``w``, and returns the
+output of ``w`` which is already wrapped inside a monad, do any necessary flattening before.
+
+To do, we could do:
+
+``bind(f(), g)``
+
+## kitten
+
+_kitten_ relies on the STL to provide functor and monad instances for some C++ data types. Given that the data type admits
+such instances, it's then possible to use the combinators available as free functions:
+
+- ``fmap``
+- ``bind``
+
+Also, to simplify notation, they also come as overloaded operators that enable a, hopefully nicer, infix syntax:
+
+- ``|`` as an alias for ``fmap``
+- ``>>`` as an alias for ``bind``
+
+The combinators are available conveniently in the header: ``kitten/kitten.h``, or by importing each one separately.
+
+## Requirements
+
+* C++17
+* Make
+* CMake
+* Conan
+* Docker
+
+Note that Docker is only required if you want to run the tests inside a container. In that case, you just need to have Make,
+since all the other requirements are shipped inside the docker image. Therefore for quick exploration and collaboration,
+
+
+## Build
+
+The _Makefile_ wraps the commands to download dependencies (Conan), generate the build configuration, build, run the
+unit tests, and clear the build folder.
+
+* Compile (by default, it also compiles the unit tests):
+
+```
+make
+```
+
+By default, it also builds the unit tests, you can disable the behavior by:
+
+```
+make WITH_TESTS=false
+```
+
+
+The build always assumes that the default profile (*profiles/common*) applies to your build. If that's not, then you
+can specify your profile by setting _PROFILE_ as:
+
+```
+make PROFILE=<path_to_your_profile>
+```
+
+* To run the unit tests:
+
+```
+make test
+```
+
+### Run unit tests inside a Docker container
+
+Optionally, it's also possible to run the unit tests inside a Docker container by executing:
+
+```
+make env-test
+```
+
+## Installing on the system
+
+To install _kitten_:
+
+```
+sudo make install
+```
+
+Then, it's possible to import _kitten_ into external CMake projects, say in a target _myExample_, by simply adding the
+following commands to its _CMakeLists.txt_:
+
+```
+find_package(kitten)
+target_link_libraries(myExample rvarago::kitten)
+```
+
+## Packaging via Conan
+
+To generate a package via Conan:
+
+```
+make conan-package
+```
+
+This will build the package _kitten_, run the test package, and then install it in the local Conan cache.

--- a/README.md
+++ b/README.md
@@ -88,6 +88,12 @@ Also, to simplify notation, they also come as overloaded operators that enable a
 
 The combinators are available conveniently in the header: ``kitten/kitten.h``, or by importing each one separately.
 
+### Adapters
+
+The following types are currently supported as both functors and monads:
+
+- ``std::optional<T>``
+
 ## Requirements
 
 * C++17

--- a/include/kitten/detail/traits.h
+++ b/include/kitten/detail/traits.h
@@ -1,0 +1,28 @@
+#ifndef RVARAGO_KITTEN_SEQUENCE_CONTAINER_H
+#define RVARAGO_KITTEN_SEQUENCE_CONTAINER_H
+
+#include <deque>
+#include <list>
+#include <vector>
+
+namespace rvarago::kitten::detail::traits {
+
+    // TODO: Use standard concepts
+    template <typename Container>
+    struct is_sequence_container final : std::false_type {};
+
+    template <typename T>
+    struct is_sequence_container<std::deque<T>> final : std::true_type {};
+
+    template <typename T>
+    struct is_sequence_container<std::list<T>> final : std::true_type {};
+
+    template <typename T>
+    struct is_sequence_container<std::vector<T>> final : std::true_type {};
+
+    template <typename Container>
+    using enable_if_sequence_container = typename std::enable_if_t<traits::is_sequence_container<Container>::value>;
+
+}
+
+#endif

--- a/include/kitten/functor.h
+++ b/include/kitten/functor.h
@@ -3,9 +3,39 @@
 
 namespace rvarago::kitten {
 
-    template<template<typename ...> typename F>
+    /**
+     * A functor is an abstraction that allows to be mapped over.
+     *
+     * Given a functor fa: F[A] and a function f: A -> B
+     *  It uses f to map over over fa and then return a new functor fb: F[B].
+     *
+     * Laws:
+     *
+     * - Identity: fmap (f . g)  ==  fmap f . fmap g
+     * - Composition: fmap id = id
+     */
+    template <template <typename ...> typename F, typename Enable = void>
     struct functor;
 
+    /**
+     * Forwards to the functor implementation.
+     *
+     * @param input a functor fa: F[A]
+     * @param f a function A -> that maps over the value wrapped inside fa to yield a value b: B
+     * @return a new functor fb: F[B] resulting from applying f over the wrapped value inside fa
+     */
+    template <typename UnaryFunction, template <typename ...> typename F, typename A, typename... Rest>
+    decltype(auto) fmap(F<A, Rest...> const& input, UnaryFunction f) {
+        return functor<F>::fmap(input, f);
+    }
+
+    /**
+     * Infix version of fmap.
+     */
+    template <typename UnaryFunction, template <typename ...> typename F, typename A, typename... Rest>
+    decltype(auto) operator|(F<A, Rest...> const& input, UnaryFunction f) {
+        return fmap(input, f);
+    }
 }
 
 #endif

--- a/include/kitten/instances/optional.h
+++ b/include/kitten/instances/optional.h
@@ -1,0 +1,36 @@
+#ifndef RVARAGO_KITTEN_OPTIONAL_H
+#define RVARAGO_KITTEN_OPTIONAL_H
+
+#include <optional>
+
+#include "kitten/functor.h"
+#include "kitten/monad.h"
+
+namespace rvarago::kitten {
+
+    template <>
+    struct monad<std::optional> {
+
+        template <typename UnaryFunction, typename A>
+        static auto bind(std::optional <A> const &input, UnaryFunction f) -> decltype(f(std::declval<A>())) {
+            if (!input.has_value()) {
+                return {};
+            }
+            return f(input.value());
+        }
+
+    };
+
+    template <>
+    struct functor<std::optional> {
+
+        template <typename UnaryFunction, typename A>
+        static auto fmap(std::optional <A> const &input, UnaryFunction f) -> std::optional<decltype(f(std::declval<A>()))> {
+            return monad<std::optional>::bind(input, [&f](auto const& value){ return std::optional{f(value)}; });
+        }
+
+    };
+
+}
+
+#endif

--- a/include/kitten/instances/sequence_container.h
+++ b/include/kitten/instances/sequence_container.h
@@ -1,0 +1,37 @@
+#ifndef RVARAGO_KITTEN_VECTOR_H
+#define RVARAGO_KITTEN_VECTOR_H
+
+#include "kitten/detail/traits.h"
+#include "kitten/functor.h"
+#include "kitten/monad.h"
+#include "kitten/ranges/algorithm.h"
+
+namespace rvarago::kitten {
+
+    template <template <typename...> typename SequenceContainer>
+    struct monad<SequenceContainer> {
+
+        template <typename UnaryFunction, typename A, typename... Rest, typename = detail::traits::enable_if_sequence_container<SequenceContainer<A, Rest...>>>
+        static auto bind(SequenceContainer<A, Rest...> const& input, UnaryFunction f) -> decltype(f(std::declval<A>())) {
+            auto mapped_sequence = decltype(f(std::declval<A>())){};
+            for (auto const& el : input) {
+                ranges::copy(f(el), std::back_inserter(mapped_sequence));
+            }
+            return mapped_sequence;
+        }
+
+    };
+
+    template <template <typename...> typename SequenceContainer>
+    struct functor<SequenceContainer> {
+
+        template <typename UnaryFunction, typename A, typename... Rest, typename = detail::traits::enable_if_sequence_container<SequenceContainer<A, Rest...>>>
+        static auto fmap(SequenceContainer<A, Rest...> const& input, UnaryFunction f) -> SequenceContainer<decltype(f(std::declval<A>()))> {
+            return monad<SequenceContainer>::bind(input, [&f](auto const& v) { return SequenceContainer{f(v)}; });
+        }
+
+    };
+
+}
+
+#endif

--- a/include/kitten/kitten.h
+++ b/include/kitten/kitten.h
@@ -1,0 +1,7 @@
+#ifndef RVARAGO_KITTEN_KITTEN_H
+#define RVARAGO_KITTEN_KITTEN_H
+
+#include "kitten/functor.h"
+#include "kitten/monad.h"
+
+#endif

--- a/include/kitten/monad.h
+++ b/include/kitten/monad.h
@@ -3,8 +3,43 @@
 
 namespace rvarago::kitten {
 
-    template<template<typename ...> typename F>
+    /**
+    * A monad is an abstraction that allows to be mapped over where the mapping function itself returns a monad.
+    *
+    * Given a monad ma: M[A] and a function f: A -> M[B]
+    *  It uses f to map over over ma, flat the return type, and then return a new monad mb: M[B].
+    *
+    * Note that if we had done as we do for functors, i.e. to do fmap(ma, f), we'd have a M[M[B]] that should then be flattened.
+    * but bind does both the mapping and then the flattening.
+    *
+    * Laws:
+    *
+    * - Left identity: return a >>= f == f a
+    * - Right identity: m >>= return == m
+    * - Associativity: (m >>= f) >>= g == m >>= (\x -> f x >>= g)
+    */
+    template <template <typename ...> typename M, typename Enable = void>
     struct monad;
+
+    /**
+     * Forwards to the monad implementation.
+     *
+     * @param input a monad ma: M[A]
+     * @param f a function A -> M[B] that maps over the value wrapped inside ma to produce a new monad mb_temp: M[B]
+     * @return a new monad mb: M[B] resulting from applying f over the wrapped value inside ma and then flattening the result
+     */
+    template <typename UnaryFunction, template <typename ...> typename M, typename A, typename... Rest>
+    decltype(auto) bind(M<A, Rest...> const& input, UnaryFunction f) {
+        return monad<M>::bind(input, f);
+    }
+
+    /**
+     * Infix version of bind.
+     */
+    template <typename UnaryFunction, template <typename ...> typename M, typename A, typename... Rest>
+    decltype(auto) operator>>(M<A, Rest...> const& input, UnaryFunction f) {
+        return bind(input, f);
+    }
 
 }
 

--- a/include/kitten/ranges/algorithm.h
+++ b/include/kitten/ranges/algorithm.h
@@ -1,0 +1,16 @@
+#ifndef RVARAGO_KITTEN_ALGORITHM_H
+#define RVARAGO_KITTEN_ALGORITHM_H
+
+#include <algorithm>
+
+namespace rvarago::kitten::ranges {
+
+    // TODO: Use standard ranges
+    template <typename Range, typename OutIterator>
+    decltype(auto) copy(Range&& range, OutIterator out) {
+        return std::copy(std::cbegin(range), std::cend(range), out);
+    }
+
+}
+
+#endif

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3,6 +3,7 @@ project(kitten_tests LANGUAGES CXX)
 set(CMAKE_MODULE_PATH ${CMAKE_BINARY_DIR})
 
 add_executable(${PROJECT_NAME}
+        optional_test.cpp
         main.cpp
 )
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4,6 +4,7 @@ set(CMAKE_MODULE_PATH ${CMAKE_BINARY_DIR})
 
 add_executable(${PROJECT_NAME}
         optional_test.cpp
+        sequence_container_test.cpp
         main.cpp
 )
 

--- a/tests/optional_test.cpp
+++ b/tests/optional_test.cpp
@@ -1,0 +1,40 @@
+#include <gtest/gtest.h>
+
+#include <string>
+#include <kitten/instances/optional.h>
+
+using namespace rvarago::kitten;
+
+namespace {
+
+    TEST(optional, fmap_should_returnEmpty_when_empty) {
+        auto const none = std::optional<int>{};
+        auto const mapped_none = none | [](auto v){ return std::to_string(v * 10); };
+
+        EXPECT_TRUE(!mapped_none.has_value());
+    }
+
+    TEST(optional, fmap_should_returnMapped_when_notEmpty) {
+        auto const some_one = std::optional<int>{1};
+        auto const mapped_some = some_one | [](auto v){ return std::to_string(v * 10); };
+
+        EXPECT_TRUE(mapped_some.has_value());
+        EXPECT_EQ("10", mapped_some.value());
+    }
+
+    TEST(optional, bind_should_returnEmpty_when_empty) {
+        auto const none = std::optional<int>{};
+        auto const mapped_none = none >> [](auto v){ return std::optional{std::to_string(v * 10)}; };
+
+        EXPECT_TRUE(!mapped_none.has_value());
+    }
+
+    TEST(optional, bind_should_returnMapped_when_notEmpty) {
+        auto const some_one = std::optional<int>{1};
+        auto const mapped_some = some_one >> [](auto v){ return std::optional{std::to_string(v * 10)}; };
+
+        EXPECT_TRUE(mapped_some.has_value());
+        EXPECT_EQ("10", mapped_some.value());
+    }
+
+}

--- a/tests/sequence_container_test.cpp
+++ b/tests/sequence_container_test.cpp
@@ -1,0 +1,73 @@
+#include <gtest/gtest.h>
+
+#include <iterator>
+#include <string>
+#include <kitten/instances/sequence_container.h>
+
+using namespace rvarago::kitten;
+
+namespace {
+
+    template <typename SequenceContainer, typename Index>
+    decltype(auto) value_at(SequenceContainer const &container, Index index) {
+        return *std::next(std::cbegin(container), index);
+    }
+
+    template <typename T>
+    struct SequenceContainerTest : public ::testing::Test {
+        using type = T;
+    };
+
+    using sequence_containers = ::testing::Types<std::deque<int>, std::list<int>, std::vector<int>>;
+
+    TYPED_TEST_CASE(SequenceContainerTest, sequence_containers);
+
+    TYPED_TEST(SequenceContainerTest, fmap_should_returnEmpty_when_empty) {
+        using T  = typename TestFixture::type;
+
+        auto const empty = T{};
+        auto const mapped_empty = empty | [](auto v){ return std::to_string(v * 10); };
+
+        EXPECT_TRUE(mapped_empty.empty());
+    }
+
+
+    TYPED_TEST(SequenceContainerTest, fmap_should_returnMapped_when_notEmpty) {
+        using T  = typename TestFixture::type;
+
+        auto const container = T{1, 2};
+        auto const mapped_container = container | [](auto v){ return std::to_string(v * 10); };
+
+        EXPECT_TRUE(!mapped_container.empty());
+        EXPECT_EQ(2, mapped_container.size());
+
+        EXPECT_EQ("10", value_at(mapped_container, 0));
+        EXPECT_EQ("20", value_at(mapped_container, 1));
+
+    }
+
+    TYPED_TEST(SequenceContainerTest, bind_should_returnEmpty_when_empty) {
+        using T  = typename TestFixture::type;
+
+        auto const empty = T{};
+        auto const mapped_empty = empty >> [](auto v){ return std::vector{std::to_string(v * 10), std::to_string(v * 100)}; };
+
+        EXPECT_TRUE(mapped_empty.empty());
+    }
+
+    TYPED_TEST(SequenceContainerTest, bind_should_returnMapped_when_notEmpty) {
+        using T  = typename TestFixture::type;
+
+        auto const container = T{1, 2};
+        auto const mapped_container = container >> [](auto v){ return std::vector{std::to_string(v * 10), std::to_string(v * 100)}; };
+
+        EXPECT_TRUE(!mapped_container.empty());
+        EXPECT_EQ(4, mapped_container.size());
+
+        EXPECT_EQ("10", value_at(mapped_container, 0));
+        EXPECT_EQ("100", value_at(mapped_container, 1));
+        EXPECT_EQ("20", value_at(mapped_container, 2));
+        EXPECT_EQ("200", value_at(mapped_container, 3));
+    }
+
+}


### PR DESCRIPTION
feature: Add support for new adapter: std::deque, std::list, std::vector
feature: Add support for new adapter: std::optional
feature: Include combinators all at once via kitten.h
Add a range-based version of std::copy
docs: Add description about motivation for having functors and monads
feature: Add free function bind for monad instances
feature: Add free function fmap for functor instances