### PR TITLE
Use constexpr for combinators and Add test package for Conan

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM conanio/gcc8:1.14.1
 
 USER root
 
-WORKDIR absent
+WORKDIR kitten
 
 COPY . .
 

--- a/include/kitten/functor.h
+++ b/include/kitten/functor.h
@@ -25,7 +25,7 @@ namespace rvarago::kitten {
      * @return a new functor fb: F[B] resulting from applying f over the wrapped value inside fa
      */
     template <typename UnaryFunction, template <typename ...> typename F, typename A, typename... Rest>
-    decltype(auto) fmap(F<A, Rest...> const& input, UnaryFunction f) {
+    constexpr decltype(auto) fmap(F<A, Rest...> const& input, UnaryFunction f) {
         return functor<F>::fmap(input, f);
     }
 
@@ -33,7 +33,7 @@ namespace rvarago::kitten {
      * Infix version of fmap.
      */
     template <typename UnaryFunction, template <typename ...> typename F, typename A, typename... Rest>
-    decltype(auto) operator|(F<A, Rest...> const& input, UnaryFunction f) {
+    constexpr decltype(auto) operator|(F<A, Rest...> const& input, UnaryFunction f) {
         return fmap(input, f);
     }
 }

--- a/include/kitten/instances/optional.h
+++ b/include/kitten/instances/optional.h
@@ -12,7 +12,7 @@ namespace rvarago::kitten {
     struct monad<std::optional> {
 
         template <typename UnaryFunction, typename A>
-        static auto bind(std::optional <A> const &input, UnaryFunction f) -> decltype(f(std::declval<A>())) {
+        static constexpr auto bind(std::optional <A> const &input, UnaryFunction f) -> decltype(f(std::declval<A>())) {
             if (!input.has_value()) {
                 return {};
             }
@@ -25,7 +25,7 @@ namespace rvarago::kitten {
     struct functor<std::optional> {
 
         template <typename UnaryFunction, typename A>
-        static auto fmap(std::optional <A> const &input, UnaryFunction f) -> std::optional<decltype(f(std::declval<A>()))> {
+        static constexpr auto fmap(std::optional <A> const &input, UnaryFunction f) -> std::optional<decltype(f(std::declval<A>()))> {
             return monad<std::optional>::bind(input, [&f](auto const& value){ return std::optional{f(value)}; });
         }
 

--- a/include/kitten/instances/sequence_container.h
+++ b/include/kitten/instances/sequence_container.h
@@ -12,7 +12,7 @@ namespace rvarago::kitten {
     struct monad<SequenceContainer> {
 
         template <typename UnaryFunction, typename A, typename... Rest, typename = detail::traits::enable_if_sequence_container<SequenceContainer<A, Rest...>>>
-        static auto bind(SequenceContainer<A, Rest...> const& input, UnaryFunction f) -> decltype(f(std::declval<A>())) {
+        static constexpr auto bind(SequenceContainer<A, Rest...> const& input, UnaryFunction f) -> decltype(f(std::declval<A>())) {
             auto mapped_sequence = decltype(f(std::declval<A>())){};
             for (auto const& el : input) {
                 ranges::copy(f(el), std::back_inserter(mapped_sequence));
@@ -26,7 +26,7 @@ namespace rvarago::kitten {
     struct functor<SequenceContainer> {
 
         template <typename UnaryFunction, typename A, typename... Rest, typename = detail::traits::enable_if_sequence_container<SequenceContainer<A, Rest...>>>
-        static auto fmap(SequenceContainer<A, Rest...> const& input, UnaryFunction f) -> SequenceContainer<decltype(f(std::declval<A>()))> {
+        static constexpr auto fmap(SequenceContainer<A, Rest...> const& input, UnaryFunction f) -> SequenceContainer<decltype(f(std::declval<A>()))> {
             return monad<SequenceContainer>::bind(input, [&f](auto const& v) { return SequenceContainer{f(v)}; });
         }
 

--- a/include/kitten/monad.h
+++ b/include/kitten/monad.h
@@ -29,7 +29,7 @@ namespace rvarago::kitten {
      * @return a new monad mb: M[B] resulting from applying f over the wrapped value inside ma and then flattening the result
      */
     template <typename UnaryFunction, template <typename ...> typename M, typename A, typename... Rest>
-    decltype(auto) bind(M<A, Rest...> const& input, UnaryFunction f) {
+    constexpr decltype(auto) bind(M<A, Rest...> const& input, UnaryFunction f) {
         return monad<M>::bind(input, f);
     }
 
@@ -37,7 +37,7 @@ namespace rvarago::kitten {
      * Infix version of bind.
      */
     template <typename UnaryFunction, template <typename ...> typename M, typename A, typename... Rest>
-    decltype(auto) operator>>(M<A, Rest...> const& input, UnaryFunction f) {
+    constexpr decltype(auto) operator>>(M<A, Rest...> const& input, UnaryFunction f) {
         return bind(input, f);
     }
 

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -1,0 +1,19 @@
+cmake_minimum_required(VERSION 3.10)
+
+project(kitten_test_package LANGUAGES CXX)
+
+set(CMAKE_MODULE_PATH ${CMAKE_BINARY_DIR})
+
+find_package(kitten REQUIRED)
+
+add_executable(${PROJECT_NAME} main.cpp)
+
+target_link_libraries(${PROJECT_NAME}
+        PRIVATE
+            kitten::kitten
+)
+
+target_compile_features(${PROJECT_NAME}
+        PRIVATE
+            cxx_std_17
+)

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -1,0 +1,16 @@
+from conans import ConanFile, CMake
+import os
+
+class KittenlsTestConan(ConanFile):
+    name        = "kitten_test_package"
+    author      = "Rafael Varago (rvarago)"
+
+    generators  = "cmake_find_package"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        self.run(".{}{}".format(os.sep, self.name))

--- a/test_package/main.cpp
+++ b/test_package/main.cpp
@@ -1,0 +1,15 @@
+#include <iostream>
+#include <optional>
+
+#include "kitten/kitten.h"
+#include "kitten/instances/optional.h"
+
+using namespace rvarago::kitten;
+
+int main() {
+    auto constexpr maybe_an_approximate_answer = std::optional{41};
+    auto constexpr exact_answer = (maybe_an_approximate_answer | [](auto const& el) { return el + 1; }).value();
+    static_assert(42 == exact_answer);
+    std::cout << "rvarago::kitten works! The exact answer is: " << exact_answer << '\n';
+    return 0;
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -8,11 +8,6 @@ add_executable(${PROJECT_NAME}
         main.cpp
 )
 
-target_compile_features(${PROJECT_NAME}
-        PRIVATE
-            cxx_std_17
-)
-
 if (${CMAKE_CXX_COMPILER_ID} MATCHES "GNU|Clang")
     target_compile_options(${PROJECT_NAME}
             PRIVATE


### PR DESCRIPTION
conan: Add test_package to test usage for downstream
tests: Remove unnecessary setting to use C++17 in the CMakeLists.txt
Use constexpr for combinators
docker: Rename WORKDIR to use kitten