### PR TITLE
Add support for either<A, E> as a left-biased alias for std::variant<A, E>

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,8 @@ Also, to simplify notation, they also come as overloaded operators that enable a
 - ``|`` as an alias for ``fmap``
 - ``>>`` as an alias for ``bind``
 
-The combinators are available conveniently in the header: ``kitten/kitten.h``, or by importing each one separately.
+The combinators are available conveniently in the header: ``kitten/kitten.h``, or by importing each one separately. And
+the main namespace is ``rvarago::kitten``.
 
 ### Adapters
 
@@ -99,6 +100,9 @@ The following types are currently supported as both functors and monads:
 - ``std::deque<T>``
 - ``std::list<T>``
 - ``std::vector<T>``
+- ``either<A, E>``: a *left-biased* alias for ``std::variant<A, E>``. And by left-biased, I mean that the mapping only
+happens for the left type parameter ``A``, for instance ``fmap`` receives a function `f: A -> B` and then
+returns ``either<B, E>``
 
 ## Requirements
 

--- a/include/kitten/instances/either.h
+++ b/include/kitten/instances/either.h
@@ -1,0 +1,42 @@
+#ifndef RVARAGO_KITTEN_EITHER_H
+#define RVARAGO_KITTEN_EITHER_H
+
+#include <variant>
+
+#include "kitten/functor.h"
+#include "kitten/monad.h"
+
+namespace rvarago::kitten {
+
+    namespace types {
+        template<typename A, typename E>
+        using either = std::variant<A, E>;
+    }
+
+    template <>
+    struct monad<std::variant> {
+
+        template <typename UnaryFunction, typename A, typename E>
+        static constexpr auto bind(std::variant<A, E> const &input, UnaryFunction f) -> decltype(f(std::declval<A>())) {
+            using ResultT = decltype(f(std::declval<A>()));
+            if (std::holds_alternative<E>(input)) {
+                return ResultT{std::get<E>(input)};
+            }
+            return f(std::get<A>(input));
+        }
+
+    };
+
+    template <>
+    struct functor<std::variant> {
+
+        template <typename UnaryFunction, typename A, typename E>
+        static constexpr auto fmap(std::variant<A, E> const &input, UnaryFunction f) -> std::variant<decltype(f(std::declval<A>())), E> {
+            return monad<std::variant>::bind(input, [&f](auto const& value){ return std::variant<decltype(f(std::declval<A>())), E>{f(value)}; });
+        }
+
+    };
+
+}
+
+#endif

--- a/include/kitten/instances/optional.h
+++ b/include/kitten/instances/optional.h
@@ -12,7 +12,7 @@ namespace rvarago::kitten {
     struct monad<std::optional> {
 
         template <typename UnaryFunction, typename A>
-        static constexpr auto bind(std::optional <A> const &input, UnaryFunction f) -> decltype(f(std::declval<A>())) {
+        static constexpr auto bind(std::optional<A> const &input, UnaryFunction f) -> decltype(f(std::declval<A>())) {
             if (!input.has_value()) {
                 return {};
             }
@@ -25,7 +25,7 @@ namespace rvarago::kitten {
     struct functor<std::optional> {
 
         template <typename UnaryFunction, typename A>
-        static constexpr auto fmap(std::optional <A> const &input, UnaryFunction f) -> std::optional<decltype(f(std::declval<A>()))> {
+        static constexpr auto fmap(std::optional<A> const &input, UnaryFunction f) -> std::optional<decltype(f(std::declval<A>()))> {
             return monad<std::optional>::bind(input, [&f](auto const& value){ return std::optional{f(value)}; });
         }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -6,6 +6,7 @@ add_executable(${PROJECT_NAME}
         optional_test.cpp
         sequence_container_test.cpp
         main.cpp
+        either_test.cpp
 )
 
 if (${CMAKE_CXX_COMPILER_ID} MATCHES "GNU|Clang")

--- a/tests/either_test.cpp
+++ b/tests/either_test.cpp
@@ -1,0 +1,47 @@
+#include <gtest/gtest.h>
+
+#include <string>
+#include <kitten/instances/either.h>
+
+using namespace rvarago::kitten;
+
+namespace {
+
+    struct error_t final {
+        explicit error_t(int _code) : code{_code} {}
+        int const code;
+    };
+
+    TEST(either, fmap_should_returnEmpty_when_empty) {
+        auto const error = types::either<int, error_t>{error_t{-1}};
+        auto const mapped_error = error | [](auto v){ return std::to_string(v * 10); };
+
+        EXPECT_TRUE(std::holds_alternative<error_t>(mapped_error));
+        EXPECT_EQ(-1, std::get<error_t>(mapped_error).code);
+    }
+
+    TEST(either, fmap_should_returnMapped_when_notEmpty) {
+        auto const value_one = types::either<int, error_t>{1};
+        auto const mapped_value = value_one | [](auto v){ return std::to_string(v * 10); };
+
+        EXPECT_TRUE(std::holds_alternative<std::string>(mapped_value));
+        EXPECT_EQ("10", std::get<std::string>(mapped_value));
+    }
+
+    TEST(either, bind_should_returnEmpty_when_empty) {
+        auto const error = types::either<int, error_t>{error_t{-1}};
+        auto const mapped_error = error >> [](auto v){ return types::either<std::string, error_t>{std::to_string(v * 10)}; };
+
+        EXPECT_TRUE(std::holds_alternative<error_t>(mapped_error));
+        EXPECT_EQ(-1, std::get<error_t>(mapped_error).code);
+    }
+
+    TEST(either, bind_should_returnMapped_when_notEmpty) {
+        auto const value_one = types::either<int, error_t>{1};
+        auto const mapped_value = value_one >> [](auto v){ return types::either<std::string, error_t>{std::to_string(v * 10)}; };
+
+        EXPECT_TRUE(std::holds_alternative<std::string>(mapped_value));
+        EXPECT_EQ("10", std::get<std::string>(mapped_value));
+    }
+
+}


### PR DESCRIPTION
That supports mapping for the left type parameter A.