### PR TITLE
change: Rename combinators fmap and nfmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Thus, the result of the whole composition is of type `std::optional<name>`.
 A multi-functor generalizes a functor in the sense that instead of having only 1 type parameter, it can have `N` different types.
 
 Given a multi-functor of arity 2, also called bi-functor,`X<A1, B1>`, and the functions `fa: A1 -> A2` and `fb: B1-> B2`,
-a multi-functor uses `nfmap` to instantiate a new bi-functor `X<A2, B2>` via mapping the types through  `fa` and `fb`.
+a multi-functor uses `mapn` to instantiate a new bi-functor `X<A2, B2>` via mapping the types through  `fa` and `fb`.
 
 An interesting use case for a multi-functor is where we have a function that returns an `std::variant<A1, B1, C1>` and we
 want to map such type to `std::variant<A2, B2, C2>` via several functions `fa: A1 -> A2`, `fb: B1 -> B2`, and `fc: C1 -> C2`
@@ -139,13 +139,13 @@ such instances, it's then possible to use the combinators available as free func
 
 - `map` for types that have functor instances
 - `bind` for types that have monad instances
-- `nfmap` for types that have multi-functor instances
+- `mapn` for types that have multi-functor instances
 
 Also, to simplify notation, they also come as overloaded operators that enable a, hopefully, nicer, infix syntax:
 
 - `|` as an alias for `map`
 - `>>` as an alias for `bind`
-- `||` as an alias for `nfmap`
+- `||` as an alias for `mapn`
 
 The combinators are available conveniently in the header: `kitten/kitten.h`, or by importing each one separately. And
 the main namespace is `rvarago::kitten`.

--- a/README.md
+++ b/README.md
@@ -45,11 +45,11 @@ Given that we can't do the usual function composition, we need a more powerful w
 
 We need a functor.
 
-If `X<T>` admits a functor for some type parameter `T`, we can compose `f` and `g` by using `fmap`:
+If `X<T>` admits a functor for some type parameter `T`, we can compose `f` and `g` by using `map` (also known as `fmap`):
 
-`fmap(X<A>, w: A -> B): X<B>`
+`map(X<A>, w: A -> B): X<B>`
 
-`fmap` receives a functor `X<A>`, a function `w: A -> B` that would do the composition of the types `A` and `B`, and
+`map` receives a functor `X<A>`, a function `w: A -> B` that would do the composition of the types `A` and `B`, and
 it returns a new functor `X<B>`. It basically:
  
 1. unwraps `X<A>` into `A`
@@ -59,12 +59,12 @@ it returns a new functor `X<B>`. It basically:
 
 Hence, we can do:
 
-`fmap(f(), g)`
+`map(f(), g)`
 
 Using _kitten_, one example of using a functor is:
 
 ```
-auto const maybe_name = maybe_find_person() | get_name; // or fmap(maybe_find_person(), get_name)
+auto const maybe_name = maybe_find_person() | get_name; // or map(maybe_find_person(), get_name)
 ```
 
 Where `maybe_find_person` returns an `std::optional<person>`, and then the wrapped object of type `person` is fed into
@@ -77,7 +77,7 @@ Thus, the result of the whole composition is of type `std::optional<name>`.
 What happens if `f` and `g` are both effectul functions: `f: A -> X<B>` and `g: B -> X<C>`. How can
 we compose `f` and `g`?
 
-If we use `fmap` as we did before, we would end up with a return type `X<X<C>>`, that nests the same effect. This type
+If we use `map` as we did before, we would end up with a return type `X<X<C>>`, that nests the same effect. This type
 would then need to be flattened, or collapsed, into an `X<C>`, we need a structure that knows how to flat the effects.
 
 We need a structure that's more powerful than a functor, we need a monad.
@@ -137,13 +137,13 @@ set of lambda expressions, and the right overload is then selected at compile-ti
 _kitten_ relies on the STL to provide functor, monad, and multi-functor instances for some C++ data types. Given that the data type admits
 such instances, it's then possible to use the combinators available as free functions:
 
-- `fmap` for types that have functor instances
+- `map` for types that have functor instances
 - `bind` for types that have monad instances
 - `nfmap` for types that have multi-functor instances
 
 Also, to simplify notation, they also come as overloaded operators that enable a, hopefully, nicer, infix syntax:
 
-- `|` as an alias for `fmap`
+- `|` as an alias for `map`
 - `>>` as an alias for `bind`
 - `||` as an alias for `nfmap`
 
@@ -166,7 +166,7 @@ The following types are currently supported:
 | `std::vector<T>`     |   x   | x       |               |
 
 - `either<A, E>` is a *left-biased* alias for `std::variant<A, E>`. And by left-biased, I mean that the mapping only
-happens for the left type parameter `A`. For instance `fmap` receives a function `f: A -> B` and then
+happens for the left type parameter `A`. For instance `map` receives a function `f: A -> B` and then
 returns `either<B, E>`.
 
 

--- a/include/kitten/functor.h
+++ b/include/kitten/functor.h
@@ -11,8 +11,8 @@ namespace rvarago::kitten {
      *
      * Laws:
      *
-     * - Identity: fmap (f . g)  ==  fmap f . fmap g
-     * - Composition: fmap id = id
+     * - Identity: map (f . g)  ==  map f . map g
+     * - Composition: map id = id
      */
     template <template <typename ...> typename F, typename Enable = void>
     struct functor;
@@ -25,16 +25,16 @@ namespace rvarago::kitten {
      * @return a new functor fb: F[B] resulting from applying f over the wrapped value inside fa
      */
     template <typename UnaryFunction, template <typename ...> typename F, typename A, typename... Rest>
-    constexpr decltype(auto) fmap(F<A, Rest...> const& input, UnaryFunction f) {
-        return functor<F>::fmap(input, f);
+    constexpr decltype(auto) map(F<A, Rest...> const& input, UnaryFunction f) {
+        return functor<F>::map(input, f);
     }
 
     /**
-     * Infix version of fmap.
+     * Infix version of map.
      */
     template <typename UnaryFunction, template <typename ...> typename F, typename A, typename... Rest>
     constexpr decltype(auto) operator|(F<A, Rest...> const& input, UnaryFunction f) {
-        return fmap(input, f);
+        return map(input, f);
     }
 }
 

--- a/include/kitten/instances/either.h
+++ b/include/kitten/instances/either.h
@@ -31,7 +31,7 @@ namespace rvarago::kitten {
     struct functor<std::variant> {
 
         template <typename UnaryFunction, typename A, typename E>
-        static constexpr auto fmap(std::variant<A, E> const &input, UnaryFunction f) -> std::variant<decltype(f(std::declval<A>())), E> {
+        static constexpr auto map(std::variant<A, E> const &input, UnaryFunction f) -> std::variant<decltype(f(std::declval<A>())), E> {
             return monad<std::variant>::bind(input, [&f](auto const& value){ return std::variant<decltype(f(std::declval<A>())), E>{f(value)}; });
         }
 

--- a/include/kitten/instances/optional.h
+++ b/include/kitten/instances/optional.h
@@ -25,7 +25,7 @@ namespace rvarago::kitten {
     struct functor<std::optional> {
 
         template <typename UnaryFunction, typename A>
-        static constexpr auto fmap(std::optional<A> const &input, UnaryFunction f) -> std::optional<decltype(f(std::declval<A>()))> {
+        static constexpr auto map(std::optional<A> const &input, UnaryFunction f) -> std::optional<decltype(f(std::declval<A>()))> {
             return monad<std::optional>::bind(input, [&f](auto const& value){ return std::optional{f(value)}; });
         }
 

--- a/include/kitten/instances/sequence_container.h
+++ b/include/kitten/instances/sequence_container.h
@@ -26,7 +26,7 @@ namespace rvarago::kitten {
     struct functor<SequenceContainer> {
 
         template <typename UnaryFunction, typename A, typename... Rest, typename = detail::traits::enable_if_sequence_container<SequenceContainer<A, Rest...>>>
-        static constexpr auto fmap(SequenceContainer<A, Rest...> const& input, UnaryFunction f) -> SequenceContainer<decltype(f(std::declval<A>()))> {
+        static constexpr auto map(SequenceContainer<A, Rest...> const& input, UnaryFunction f) -> SequenceContainer<decltype(f(std::declval<A>()))> {
             return monad<SequenceContainer>::bind(input, [&f](auto const& v) { return SequenceContainer{f(v)}; });
         }
 

--- a/include/kitten/instances/variant.h
+++ b/include/kitten/instances/variant.h
@@ -22,7 +22,7 @@ namespace rvarago::kitten {
     struct multifunctor<std::variant> {
 
         template <typename UnaryFunction, typename... Rest>
-        static constexpr auto nfmap(std::variant<Rest...> const &input, UnaryFunction f) -> std::variant<decltype(f(std::declval<Rest>()))...> {
+        static constexpr auto mapn(std::variant<Rest...> const &input, UnaryFunction f) -> std::variant<decltype(f(std::declval<Rest>()))...> {
             using ResultT = std::variant<decltype(f(std::declval<Rest>()))...>;
             return std::visit([&f](auto const& value){ return ResultT{f(value)}; }, input);
         }

--- a/include/kitten/monad.h
+++ b/include/kitten/monad.h
@@ -9,7 +9,7 @@ namespace rvarago::kitten {
     * Given a monad ma: M[A] and a function f: A -> M[B]
     *  It uses f to map over over ma, flat the return type, and then return a new monad mb: M[B].
     *
-    * Note that if we had done as we do for functors, i.e. to do fmap(ma, f), we'd have a M[M[B]] that should then be flattened.
+    * Note that if we had done as we do for functors, i.e. to do map(ma, f), we'd have a M[M[B]] that should then be flattened.
     * but bind does both the mapping and then the flattening.
     *
     * Laws:

--- a/include/kitten/multifunctor.h
+++ b/include/kitten/multifunctor.h
@@ -20,16 +20,16 @@ namespace rvarago::kitten {
      * @return a new multifunctor fb: F[A2, ..., Z2] resulting from applying f over the wrapped value inside fa
      */
     template <typename UnaryFunction, template <typename ...> typename MF, typename... Rest>
-    constexpr decltype(auto) nfmap(MF<Rest...> const& input, UnaryFunction f) {
-        return multifunctor<MF>::nfmap(input, f);
+    constexpr decltype(auto) mapn(MF<Rest...> const& input, UnaryFunction f) {
+        return multifunctor<MF>::mapn(input, f);
     }
 
     /**
-     * Infix version of nfmap.
+     * Infix version of mapn.
      */
     template <typename UnaryFunction, template <typename ...> typename MF, typename A, typename... Rest>
     constexpr decltype(auto) operator||(MF<A, Rest...> const& input, UnaryFunction f) {
-        return nfmap(input, f);
+        return mapn(input, f);
     }
 }
 

--- a/tests/either_test.cpp
+++ b/tests/either_test.cpp
@@ -15,7 +15,7 @@ namespace {
         int const code;
     };
 
-    TEST(either, fmap_should_returnEmpty_when_empty) {
+    TEST(either, map_should_returnEmpty_when_empty) {
         auto const error = types::either<int, error_t>{error_t{-1}};
         auto const mapped_error = error | [](auto v){ return std::to_string(v * 10); };
 
@@ -25,7 +25,7 @@ namespace {
         EXPECT_EQ(-1, std::get<error_t>(mapped_error).code);
     }
 
-    TEST(either, fmap_should_returnMapped_when_notEmpty) {
+    TEST(either, map_should_returnMapped_when_notEmpty) {
         auto const value_one = types::either<int, error_t>{1};
         auto const mapped_value = value_one | [](auto v){ return std::to_string(v * 10); };
 

--- a/tests/optional_test.cpp
+++ b/tests/optional_test.cpp
@@ -10,7 +10,7 @@ using test::utils::is_same_after_decaying;
 
 namespace {
 
-    TEST(optional, fmap_should_returnEmpty_when_empty) {
+    TEST(optional, map_should_returnEmpty_when_empty) {
         auto const none = std::optional<int>{};
         auto const mapped_none = none | [](auto v){ return std::to_string(v * 10); };
 
@@ -19,7 +19,7 @@ namespace {
         EXPECT_TRUE(!mapped_none.has_value());
     }
 
-    TEST(optional, fmap_should_returnMapped_when_notEmpty) {
+    TEST(optional, map_should_returnMapped_when_notEmpty) {
         auto const some_one = std::optional<int>{1};
         auto const mapped_some = some_one | [](auto v){ return std::to_string(v * 10); };
 

--- a/tests/sequence_container_test.cpp
+++ b/tests/sequence_container_test.cpp
@@ -22,7 +22,7 @@ namespace {
 
     TYPED_TEST_CASE(SequenceContainerTest, sequence_containers);
 
-    TYPED_TEST(SequenceContainerTest, fmap_should_returnEmpty_when_empty) {
+    TYPED_TEST(SequenceContainerTest, map_should_returnEmpty_when_empty) {
         using T  = typename TestFixture::type;
 
         auto const empty = T{};
@@ -32,7 +32,7 @@ namespace {
     }
 
 
-    TYPED_TEST(SequenceContainerTest, fmap_should_returnMapped_when_notEmpty) {
+    TYPED_TEST(SequenceContainerTest, map_should_returnMapped_when_notEmpty) {
         using T  = typename TestFixture::type;
 
         auto const container = T{1, 2};

--- a/tests/variant_test.cpp
+++ b/tests/variant_test.cpp
@@ -18,7 +18,7 @@ namespace {
         int const code;
     };
 
-    TEST(variant, nfmap_should_returnEmpty_when_empty) {
+    TEST(variant, mapn_should_returnEmpty_when_empty) {
         auto const error = std::variant<int, std::string, error_t>{error_t{-1}};
         auto const mapped_error = error || syntax::overloaded {
                 [](int v) { return std::optional{v * 10}; },
@@ -32,7 +32,7 @@ namespace {
         EXPECT_EQ(-2, std::get<error_t>(mapped_error).code);
     }
 
-    TEST(variant, nfmap_should_returnMapped_when_notEmpty) {
+    TEST(variant, mapn_should_returnMapped_when_notEmpty) {
         auto const integer = std::variant<int, std::string, error_t>{1};
         auto const mapped_optional_of_integer = integer|| syntax::overloaded {
                 [](int v) { return std::optional{v * 10}; },


### PR DESCRIPTION
* fmap => map
* nfmap => mapn

I think they might be better names for C++.