### PR TITLE
Add new structure: Applicative that allows for mapping over an n-ary function

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,10 +222,10 @@ The following types are currently supported:
 |:--------------------:|:-------:|-------------|-------|:-------------:|
 |    `either<A, E>`    |    x    |     x       | x     |               |
 |  `std::optional<T>`  |    x    |     x       | x     |               |
-|    `std::deque<T>`   |    x    |             | x     |               |
-|    `std::list<T>`    |    x    |             | x     |               |
+|    `std::deque<T>`   |    x    |     x       | x     |               |
+|    `std::list<T>`    |    x    |     x       | x     |               |
 | `std::variant<T...>` |         |             |       |       x       |
-|   `std::vector<T>`   |    x    |             |       |               |
+|   `std::vector<T>`   |    x    |     x       |       |               |
 
 - `either<A, E>` is a *left-biased* alias for `std::variant<A, E>`. And by left-biased, I mean that the mapping only
 happens for the left type parameter `A`. For instance `map` receives a function `f: A -> B` and then

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Thus, the result of the whole composition is of type `std::optional<name>`.
 A multi-functor generalizes a functor in the sense that instead of having only 1 type parameter, it can have `N` different types.
 
 Given a multi-functor of arity 2, also called bi-functor,`X<A1, B1>`, and the functions `fa: A1 -> A2` and `fb: B1-> B2`,
-a multi-functor uses `mapn` to instantiate a new bi-functor `X<A2, B2>` via mapping the types through  `fa` and `fb`.
+a multi-functor uses `multimap` to instantiate a new bi-functor `X<A2, B2>` via mapping the types through  `fa` and `fb`.
 
 An interesting use case for a multi-functor is where we have a function that returns an `std::variant<A1, B1, C1>` and we
 want to map such type to `std::variant<A2, B2, C2>` via several functions `fa: A1 -> A2`, `fb: B1 -> B2`, and `fc: C1 -> C2`
@@ -141,13 +141,13 @@ such instances, it's then possible to use the combinators available as free func
 
 - `map` for types that have functor instances
 - `bind` for types that have monad instances
-- `mapn` for types that have multi-functor instances
+- `multimap` for types that have multi-functor instances
 
 Also, to simplify notation, they also come as overloaded operators that enable a, hopefully, nicer, infix syntax:
 
 - `|` as an alias for `map`
 - `>>` as an alias for `bind`
-- `||` as an alias for `mapn`
+- `||` as an alias for `multimap`
 
 The combinators are available conveniently in the header: `kitten/kitten.h`, or by importing each one separately. And
 the main namespace is `rvarago::kitten`.

--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ The following types are currently supported:
 
 |         Type         | Functor | Applicative | Monad | Multi-functor |
 |:--------------------:|:-------:|-------------|-------|:-------------:|
-|    `either<A, E>`    |    x    |             | x     |               |
+|    `either<A, E>`    |    x    |     x       | x     |               |
 |  `std::optional<T>`  |    x    |     x       | x     |               |
 |    `std::deque<T>`   |    x    |             | x     |               |
 |    `std::list<T>`    |    x    |             | x     |               |

--- a/README.md
+++ b/README.md
@@ -74,6 +74,64 @@ Where `maybe_find_person` returns an `std::optional<person>`, and then the wrapp
 
 Thus, the result of the whole composition is of type `std::optional<name>`.
 
+### Applicatives
+
+What happens if `f` takes several arguments? For instance, we have the objects `xa: X<A>` and `xb: X<B>` and the
+function `f: (A, B) -> C`.
+How can we combine two effects `xa` and `xb` via `f` to obtain `X<C>`?
+
+If we use `map` as we did before, we wouldn't be able, because `map` accepts only one argument, and we need to somehow
+provide two.
+
+We need a structure that's more powerful than a functor, we need an applicative.
+
+If `X<T>` admits an applicative for some type parameter `T`, we can compose `f` using `combine` (also called `liftA2`):
+
+`combine(X<A>, X<B>, w: (A, B) -> C): X<C>`
+
+`combine` receives the applicatives `X<A>` and `X<B>`, a binary function `w: (A, B) -> C` that would do the composition
+of the types `A` and `B`, and it returns a new applicative `X<B>`. It basically:
+
+1. unwraps `X<A>` into `A`
+2. unwraps `X<B>` into `B`
+3. feeds `A` and `B` into `w`
+3. wraps the result `C` into `X<C>`
+4. then returns `X<C>`
+
+Hence, we can do:
+
+`combine(xa, xb, f)`
+
+Using _kitten_, one example of using an applicative is:
+
+```
+auto const maybe_three = maybe_one() + maybe_two(); // or combine(maybe_one(), maybe_two(), std::plus{})
+```
+
+Where `maybe_one` and `maybe_two` return instances of `std::optional<int>`, and then unwrapped objects of types
+`int` and `int` are fed into operator `+` (that defaults to `std::plus{}` for the unwrapped types) that returns an object
+of type `int` which is finally wrapped again in an `std::optional<int>`.
+
+Thus, the result of the whole composition is of type `std::optional<int>`.
+
+And what happens if we have n-ary rather than binary function `f`?
+
+We can simply chaining operator `+`, like:
+
+```
+auto const maybe_ten = maybe_one() + maybe_two() + maybe_three() + maybe_four(); // and so on ...
+```
+
+And what should we do if we need a different operation instead of addition?
+
+Given that operator `+` accepts two parameters, we have to use a convenient and general overload that accepts the a tuple of applicatives:
+
+```
+auto const maybe_six_as_string = std::tuple{maybe_two, maybe_three} + [](auto const& first, auto const& second) {
+            return std::to_string(first * second);
+};
+```
+
 ### Monads
 
 What happens if `f` and `g` are both effectul functions: `f: A -> X<B>` and `g: B -> X<C>`. How can
@@ -136,16 +194,18 @@ set of lambda expressions, and the right overload is then selected at compile-ti
 
 ## kitten
 
-_kitten_ relies on the STL to provide functor, monad, and multi-functor instances for some C++ data types. Given that the data type admits
+_kitten_ relies on the STL to provide functor, applicative, monad, and multi-functor instances for some C++ data types. Given that the data type admits
 such instances, it's then possible to use the combinators available as free functions:
 
 - `map` for types that have functor instances
+- `combine` for types that have applicative instances
 - `bind` for types that have monad instances
 - `multimap` for types that have multi-functor instances
 
 Also, to simplify notation, they also come as overloaded operators that enable a, hopefully, nicer, infix syntax:
 
 - `|` as an alias for `map`
+- `+` as an alias for `combine`
 - `>>` as an alias for `bind`
 - `||` as an alias for `multimap`
 
@@ -158,20 +218,18 @@ Note that it's possible that a type may not admit instances for all the structur
 
 The following types are currently supported:
 
-|         Type         | Functor | Monad | Multi-functor |
-|:--------------------:|:-----:|:-------:|:-------------:|
-| `either<A, E>`       |   x   | x       |               |
-| `std::deque<T>`      |   x   | x       |               |
-| `std::list<T>`       |   x   | x       |               |
-| `std::optional<T>`   |   x   | x       |               |
-| `std::variant<Ts...>`|       |         | x             |
-| `std::vector<T>`     |   x   | x       |               |
+|         Type         | Functor | Applicative | Monad | Multi-functor |
+|:--------------------:|:-------:|-------------|-------|:-------------:|
+|    `either<A, E>`    |    x    |             | x     |               |
+|  `std::optional<T>`  |    x    |             | x     |               |
+|    `std::deque<T>`   |    x    |             | x     |               |
+|    `std::list<T>`    |    x    |             | x     |               |
+| `std::variant<T...>` |         |             |       |       x       |
+|   `std::vector<T>`   |    x    |             |       |               |
 
 - `either<A, E>` is a *left-biased* alias for `std::variant<A, E>`. And by left-biased, I mean that the mapping only
 happens for the left type parameter `A`. For instance `map` receives a function `f: A -> B` and then
 returns `either<B, E>`.
-
-
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ The following types are currently supported:
 |         Type         | Functor | Applicative | Monad | Multi-functor |
 |:--------------------:|:-------:|-------------|-------|:-------------:|
 |    `either<A, E>`    |    x    |             | x     |               |
-|  `std::optional<T>`  |    x    |             | x     |               |
+|  `std::optional<T>`  |    x    |     x       | x     |               |
 |    `std::deque<T>`   |    x    |             | x     |               |
 |    `std::list<T>`    |    x    |             | x     |               |
 | `std::variant<T...>` |         |             |       |       x       |

--- a/include/kitten/applicative.h
+++ b/include/kitten/applicative.h
@@ -1,0 +1,51 @@
+#ifndef RVARAGO_KITTEN_APPLICATIVE_H
+#define RVARAGO_KITTEN_APPLICATIVE_H
+
+#include <functional>
+#include <tuple>
+
+namespace rvarago::kitten {
+
+    /**
+     * An applicative is an abstraction that allows the combination of two wrapped values.
+     *
+     * Given two applicatives apa1: AP[A] and  apa2: AP[A] and a binary function f: A -> A -> B
+     *  It uses f to map over apa1 and apa2 and then return a new applicative apb: AP[B].
+     *
+     */
+    template <template <typename ...> typename AP, typename = void>
+    struct applicative;
+
+    /**
+     * Forwards to the applicative implementation.
+     *
+     * @param first an applicative apa1: AP[A]
+     * @param second an applicative apa2: AP[A]
+     * @param f a function A -> A -> B that maps over the values wrapped inside apa1 and apa2 to yield a value b: B
+     * @return a new applicative apb: AP[B] resulting from applying f over the wrapped value inside apa1 and apa2
+     */
+    template <typename BinaryFunction, template <typename ...> typename AP, typename A, typename B, typename... Rest>
+    constexpr decltype(auto) combine(AP<A, Rest...> const& first, AP<B, Rest...> const& second, BinaryFunction f) {
+        return applicative<AP>::combine(first, second, f);
+    }
+
+
+    /**
+     * Infix version of combine. Since operator+ expects two arguments, we had to wrap the applicatives in a tuple.
+     */
+    template <typename BinaryFunction, template <typename ...> typename AP, typename A, typename B, typename... Rest>
+    constexpr decltype(auto) operator+(std::tuple<AP<A, Rest...>, AP<B, Rest...>> const& input, BinaryFunction f) {
+        return combine(std::get<0>(input), std::get<1>(input), f);
+    }
+
+    /**
+     * Infix version of combine that receives unwrapped applicatives and uses + as a binary function.
+     */
+    template <template <typename ...> typename AP, typename A, typename B, typename... Rest>
+    constexpr decltype(auto) operator+(AP<A, Rest...> const& first, AP<B, Rest...> const& second) {
+        return combine(first, second, std::plus{});
+    }
+
+}
+
+#endif

--- a/include/kitten/functor.h
+++ b/include/kitten/functor.h
@@ -7,7 +7,7 @@ namespace rvarago::kitten {
      * A functor is an abstraction that allows to be mapped over.
      *
      * Given a functor fa: F[A] and a function f: A -> B
-     *  It uses f to map over over fa and then return a new functor fb: F[B].
+     *  It uses f to map over fa and then return a new functor fb: F[B].
      *
      * Laws:
      *

--- a/include/kitten/instances/either.h
+++ b/include/kitten/instances/either.h
@@ -3,6 +3,7 @@
 
 #include <variant>
 
+#include "kitten/applicative.h"
 #include "kitten/functor.h"
 #include "kitten/monad.h"
 
@@ -12,6 +13,24 @@ namespace rvarago::kitten {
         template<typename A, typename E>
         using either = std::variant<A, E>;
     }
+
+    template <>
+    struct applicative<std::variant> {
+
+        template <typename BinaryFunction, typename A, typename B, typename E>
+        static constexpr auto combine(std::variant<A, E> const &first, std::variant<B, E> const& second, BinaryFunction f) -> std::variant<decltype(f(std::declval<A>(), std::declval<B>())), E> {
+            if (std::holds_alternative<A>(first) && std::holds_alternative<B>(second)) {
+                return f(std::get<A>(first), std::get<B>(second));
+            }
+
+            if (std::holds_alternative<E>(first)) {
+                return std::get<E>(first);
+            }
+
+            return std::get<E>(second);
+        }
+
+    };
 
     template <>
     struct monad<std::variant> {

--- a/include/kitten/instances/optional.h
+++ b/include/kitten/instances/optional.h
@@ -3,10 +3,24 @@
 
 #include <optional>
 
+#include "kitten/applicative.h"
 #include "kitten/functor.h"
 #include "kitten/monad.h"
 
 namespace rvarago::kitten {
+
+    template <>
+    struct applicative<std::optional> {
+
+        template <typename BinaryFunction, typename A, typename B>
+        static constexpr auto combine(std::optional<A> const &first, std::optional<B> const& second, BinaryFunction f) -> std::optional<decltype(f(std::declval<A>(), std::declval<B>()))> {
+            if (!first.has_value() || !second.has_value()) {
+                return {};
+            }
+            return f(first.value(), second.value());
+        }
+
+    };
 
     template <>
     struct monad<std::optional> {

--- a/include/kitten/instances/sequence_container.h
+++ b/include/kitten/instances/sequence_container.h
@@ -2,11 +2,29 @@
 #define RVARAGO_KITTEN_SEQUENCE_CONTAINER_H
 
 #include "kitten/detail/traits.h"
+#include "kitten/applicative.h"
 #include "kitten/functor.h"
 #include "kitten/monad.h"
 #include "kitten/ranges/algorithm.h"
 
 namespace rvarago::kitten {
+
+    template <template <typename...> typename SequenceContainer>
+    struct applicative<SequenceContainer> {
+
+        template <typename BinaryFunction, typename A, typename B, typename... Rest, typename = detail::traits::enable_if_sequence_container<SequenceContainer<A, Rest...>>>
+        static constexpr auto combine(SequenceContainer<A, Rest...> const &first, SequenceContainer<B, Rest...> const& second, BinaryFunction f) -> SequenceContainer<decltype(f(std::declval<A>(), std::declval<B>()))> {
+            using ValueT = decltype(f(std::declval<A>(), std::declval<B>()));
+            auto combined_sequence = SequenceContainer<ValueT>{};
+            for (auto const& first_element : first) {
+                for (auto const& second_element: second) {
+                    combined_sequence.push_back(f(first_element, second_element));
+                }
+            }
+            return combined_sequence;
+        }
+
+    };
 
     template <template <typename...> typename SequenceContainer>
     struct monad<SequenceContainer> {

--- a/include/kitten/instances/variant.h
+++ b/include/kitten/instances/variant.h
@@ -22,7 +22,7 @@ namespace rvarago::kitten {
     struct multifunctor<std::variant> {
 
         template <typename UnaryFunction, typename... Rest>
-        static constexpr auto mapn(std::variant<Rest...> const &input, UnaryFunction f) -> std::variant<decltype(f(std::declval<Rest>()))...> {
+        static constexpr auto multimap(std::variant<Rest...> const &input, UnaryFunction f) -> std::variant<decltype(f(std::declval<Rest>()))...> {
             using ResultT = std::variant<decltype(f(std::declval<Rest>()))...>;
             return std::visit([&f](auto const& value){ return ResultT{f(value)}; }, input);
         }

--- a/include/kitten/kitten.h
+++ b/include/kitten/kitten.h
@@ -1,6 +1,7 @@
 #ifndef RVARAGO_KITTEN_KITTEN_H
 #define RVARAGO_KITTEN_KITTEN_H
 
+#include "kitten/applicative.h"
 #include "kitten/functor.h"
 #include "kitten/monad.h"
 #include "kitten/multifunctor.h"

--- a/include/kitten/kitten.h
+++ b/include/kitten/kitten.h
@@ -3,5 +3,6 @@
 
 #include "kitten/functor.h"
 #include "kitten/monad.h"
+#include "kitten/multifunctor.h"
 
 #endif

--- a/include/kitten/multifunctor.h
+++ b/include/kitten/multifunctor.h
@@ -20,16 +20,16 @@ namespace rvarago::kitten {
      * @return a new multifunctor fb: F[A2, ..., Z2] resulting from applying f over the wrapped value inside fa
      */
     template <typename UnaryFunction, template <typename ...> typename MF, typename... Rest>
-    constexpr decltype(auto) mapn(MF<Rest...> const& input, UnaryFunction f) {
-        return multifunctor<MF>::mapn(input, f);
+    constexpr decltype(auto) multimap(MF<Rest...> const& input, UnaryFunction f) {
+        return multifunctor<MF>::multimap(input, f);
     }
 
     /**
-     * Infix version of mapn.
+     * Infix version of multimap.
      */
     template <typename UnaryFunction, template <typename ...> typename MF, typename A, typename... Rest>
     constexpr decltype(auto) operator||(MF<A, Rest...> const& input, UnaryFunction f) {
-        return mapn(input, f);
+        return multimap(input, f);
     }
 }
 

--- a/tests/either_test.cpp
+++ b/tests/either_test.cpp
@@ -55,4 +55,43 @@ namespace {
         EXPECT_EQ("10", std::get<std::string>(mapped_value));
     }
 
+    TEST(either, apply_should_returnEmpty_when_empty) {
+        auto const error = types::either<int, error_t>{error_t{-1}};
+        auto const some_three = types::either<int, error_t>{3};
+
+        auto const sum = error + some_three;
+        auto const product_as_string = std::tuple{some_three, error} + [](auto const& first, auto const& second) {
+            return std::to_string(first * second);
+        };
+
+        static_assert(is_same_after_decaying<types::either<int, error_t>, decltype(sum)>);
+        static_assert(is_same_after_decaying<types::either<std::string, error_t>, decltype(product_as_string)>);
+
+        EXPECT_TRUE(std::holds_alternative<error_t>(sum));
+        EXPECT_EQ(-1, std::get<error_t>(sum).code);
+
+        EXPECT_TRUE(std::holds_alternative<error_t>(product_as_string));
+        EXPECT_EQ(-1, std::get<error_t>(product_as_string).code);
+    }
+
+    TEST(either, apply_should_returnCombined_when_notEmpty) {
+        auto const some_two = types::either<int, error_t>{2};
+        auto const some_three = types::either<int, error_t>{3};
+
+        auto const sum = some_two + some_three;
+        auto const product_as_string = std::tuple{some_three, some_two} + [](auto const& first, auto const& second) {
+            return std::to_string(first * second);
+        };
+
+        static_assert(is_same_after_decaying<types::either<int, error_t>, decltype(sum)>);
+        static_assert(is_same_after_decaying<types::either<std::string, error_t>, decltype(product_as_string)>);
+
+
+        EXPECT_TRUE(std::holds_alternative<int>(sum));
+        EXPECT_EQ(5, std::get<int>(sum));
+
+        EXPECT_TRUE(std::holds_alternative<std::string>(product_as_string));
+        EXPECT_EQ("6", std::get<std::string>(product_as_string));
+    }
+
 }

--- a/tests/optional_test.cpp
+++ b/tests/optional_test.cpp
@@ -48,4 +48,39 @@ namespace {
         EXPECT_EQ("10", mapped_some.value());
     }
 
+    TEST(optional, apply_should_returnEmpty_when_empty) {
+        auto const none = std::optional<int>{};
+        auto const some_three= std::optional<int>{3};
+
+        auto const sum = none + some_three;
+        auto const product_as_string = std::tuple{some_three, none} + [](auto const& first, auto const& second) {
+            return std::to_string(first * second);
+        };
+
+        static_assert(is_same_after_decaying<std::optional<int>, decltype(sum)>);
+        static_assert(is_same_after_decaying<std::optional<std::string>, decltype(product_as_string)>);
+
+        EXPECT_TRUE(!sum.has_value());
+        EXPECT_TRUE(!product_as_string.has_value());
+    }
+
+    TEST(optional, apply_should_returnCombined_when_notEmpty) {
+        auto const some_two = std::optional<int>{2};
+        auto const some_three = std::optional<int>{3};
+
+        auto const sum = some_two + some_three;
+        auto const product_as_string = std::tuple{some_three, some_two} + [](auto const& first, auto const& second) {
+            return std::to_string(first * second);
+        };
+
+        static_assert(is_same_after_decaying<std::optional<int>, decltype(sum)>);
+        static_assert(is_same_after_decaying<std::optional<std::string>, decltype(product_as_string)>);
+
+        EXPECT_TRUE(sum.has_value());
+        EXPECT_EQ(5, sum.value());
+        EXPECT_TRUE(product_as_string.has_value());
+        EXPECT_EQ("6", product_as_string.value());
+    }
+
+
 }

--- a/tests/sequence_container_test.cpp
+++ b/tests/sequence_container_test.cpp
@@ -70,4 +70,46 @@ namespace {
         EXPECT_EQ("200", value_at(mapped_container, 3));
     }
 
+    TYPED_TEST(SequenceContainerTest, apply_should_returnEmpty_when_notEmpty) {
+        using T  = typename TestFixture::type;
+        auto const empty = T{};
+        auto const second_container = T{20, 30};
+
+        auto const sum = empty + second_container;
+        auto const product_as_string = std::tuple{second_container, empty} + [](auto const& first, auto const& second) {
+            return std::to_string(first * second);
+        };
+
+        EXPECT_TRUE(sum.empty());
+
+        EXPECT_TRUE(product_as_string.empty());
+    }
+
+    TYPED_TEST(SequenceContainerTest, apply_should_returnCombined_when_notEmpty) {
+        using T  = typename TestFixture::type;
+        auto const first_container = T{2, 3};
+        auto const second_container = T{20, 30};
+
+        auto const sum = first_container + second_container;
+        auto const product_as_string = std::tuple{second_container, first_container} + [](auto const& first, auto const& second) {
+            return std::to_string(first * second);
+        };
+
+        EXPECT_TRUE(!sum.empty());
+        EXPECT_EQ(4, sum.size());
+
+        EXPECT_EQ(22, value_at(sum, 0));
+        EXPECT_EQ(32, value_at(sum, 1));
+        EXPECT_EQ(23, value_at(sum, 2));
+        EXPECT_EQ(33, value_at(sum, 3));
+
+        EXPECT_TRUE(!product_as_string.empty());
+        EXPECT_EQ(4, product_as_string.size());
+
+        EXPECT_EQ("40", value_at(product_as_string, 0));
+        EXPECT_EQ("60", value_at(product_as_string, 1));
+        EXPECT_EQ("60", value_at(product_as_string, 2));
+        EXPECT_EQ("90", value_at(product_as_string, 3));
+    }
+
 }


### PR DESCRIPTION
An applicative, also called applicative functor, extends a functor by allowing the application of a function of several parameters rather than unary functions as we have for functors.

It admits a function combine (also aliased as +):

combine(X[A], X[B], w: (A, B) -> C): X[C] 

Where X[A], X[B], and X[C] are applicatives and w is a binary function that accepts A and B and returns C.

* feature: Extend std::(deque|list|vector)<T> to be applicatives
* feature: Extend SequenceContainer<T> to be an applicative
* feature: Extend std::optional<T> to be an applicative
* feature: Add new structure: Applicative
* change: Rename mapn to multimap
* docs: Remove duplicated word
* api: Include multifunctor.h via kitten.h