### PR TITLE
Improve usability by simulating concepts via static asserts

### DIFF
--- a/include/kitten/applicative.h
+++ b/include/kitten/applicative.h
@@ -16,6 +16,14 @@ namespace rvarago::kitten {
     template <template <typename ...> typename AP, typename = void>
     struct applicative;
 
+    namespace detail {
+        template <template <typename ...> typename, typename = void>
+        struct is_applicative : std::false_type{};
+
+        template <template <typename ...> typename AP>
+        inline constexpr bool is_applicative_v = is_applicative<AP>::value;
+    }
+
     /**
      * Forwards to the applicative implementation.
      *
@@ -26,6 +34,7 @@ namespace rvarago::kitten {
      */
     template <typename BinaryFunction, template <typename ...> typename AP, typename A, typename B, typename... Rest>
     constexpr decltype(auto) combine(AP<A, Rest...> const& first, AP<B, Rest...> const& second, BinaryFunction f) {
+        static_assert(detail::is_applicative_v<AP>, "type constructor AP does not have an applicative instance");
         return applicative<AP>::combine(first, second, f);
     }
 

--- a/include/kitten/detail/traits.h
+++ b/include/kitten/detail/traits.h
@@ -8,19 +8,19 @@
 namespace rvarago::kitten::detail::traits {
 
     // TODO: Use standard concepts
-    template <typename Container>
-    struct is_sequence_container final : std::false_type {};
+    template <template <typename ...> typename Container>
+    struct is_sequence_container : std::false_type {};
 
-    template <typename T>
-    struct is_sequence_container<std::deque<T>> final : std::true_type {};
+    template <>
+    struct is_sequence_container<std::deque> : std::true_type {};
 
-    template <typename T>
-    struct is_sequence_container<std::list<T>> final : std::true_type {};
+    template <>
+    struct is_sequence_container<std::list> : std::true_type {};
 
-    template <typename T>
-    struct is_sequence_container<std::vector<T>> final : std::true_type {};
+    template <>
+    struct is_sequence_container<std::vector> : std::true_type {};
 
-    template <typename Container>
+    template <template <typename ...> typename Container>
     using enable_if_sequence_container = typename std::enable_if_t<traits::is_sequence_container<Container>::value>;
 
 }

--- a/include/kitten/functor.h
+++ b/include/kitten/functor.h
@@ -17,6 +17,14 @@ namespace rvarago::kitten {
     template <template <typename ...> typename F, typename = void>
     struct functor;
 
+    namespace detail {
+        template <template <typename ...> typename, typename = void>
+        struct is_functor : std::false_type{};
+
+        template <template <typename ...> typename F>
+        inline constexpr bool is_functor_v = is_functor<F>::value;
+    }
+
     /**
      * Forwards to the functor implementation.
      *
@@ -26,6 +34,7 @@ namespace rvarago::kitten {
      */
     template <typename UnaryFunction, template <typename ...> typename F, typename A, typename... Rest>
     constexpr decltype(auto) map(F<A, Rest...> const& input, UnaryFunction f) {
+        static_assert(detail::is_functor_v<F>, "type constructor F does not have a functor instance");
         return functor<F>::map(input, f);
     }
 

--- a/include/kitten/instances/either.h
+++ b/include/kitten/instances/either.h
@@ -61,6 +61,9 @@ namespace rvarago::kitten {
         struct is_monad<std::variant> : std::true_type{};
 
         template <>
+        struct is_applicative<std::variant> : std::true_type{};
+
+        template <>
         struct is_functor<std::variant> : std::true_type{};
     }
 

--- a/include/kitten/instances/either.h
+++ b/include/kitten/instances/either.h
@@ -59,6 +59,9 @@ namespace rvarago::kitten {
     namespace detail {
         template <>
         struct is_monad<std::variant> : std::true_type{};
+
+        template <>
+        struct is_functor<std::variant> : std::true_type{};
     }
 
 }

--- a/include/kitten/instances/either.h
+++ b/include/kitten/instances/either.h
@@ -15,6 +15,20 @@ namespace rvarago::kitten {
     }
 
     template <>
+    struct monad<std::variant> {
+
+        template <typename UnaryFunction, typename A, typename E>
+        static constexpr auto bind(std::variant<A, E> const &input, UnaryFunction f) -> decltype(f(std::declval<A>())) {
+            using ResultT = decltype(f(std::declval<A>()));
+            if (std::holds_alternative<E>(input)) {
+                return ResultT{std::get<E>(input)};
+            }
+            return f(std::get<A>(input));
+        }
+
+    };
+
+    template <>
     struct applicative<std::variant> {
 
         template <typename BinaryFunction, typename A, typename B, typename E>
@@ -33,20 +47,6 @@ namespace rvarago::kitten {
     };
 
     template <>
-    struct monad<std::variant> {
-
-        template <typename UnaryFunction, typename A, typename E>
-        static constexpr auto bind(std::variant<A, E> const &input, UnaryFunction f) -> decltype(f(std::declval<A>())) {
-            using ResultT = decltype(f(std::declval<A>()));
-            if (std::holds_alternative<E>(input)) {
-                return ResultT{std::get<E>(input)};
-            }
-            return f(std::get<A>(input));
-        }
-
-    };
-
-    template <>
     struct functor<std::variant> {
 
         template <typename UnaryFunction, typename A, typename E>
@@ -55,6 +55,11 @@ namespace rvarago::kitten {
         }
 
     };
+
+    namespace detail {
+        template <>
+        struct is_monad<std::variant> : std::true_type{};
+    }
 
 }
 

--- a/include/kitten/instances/optional.h
+++ b/include/kitten/instances/optional.h
@@ -50,6 +50,9 @@ namespace rvarago::kitten {
         struct is_monad<std::optional> : std::true_type{};
 
         template <>
+        struct is_applicative<std::optional> : std::true_type{};
+
+        template <>
         struct is_functor<std::optional> : std::true_type{};
     }
 

--- a/include/kitten/instances/optional.h
+++ b/include/kitten/instances/optional.h
@@ -10,19 +10,6 @@
 namespace rvarago::kitten {
 
     template <>
-    struct applicative<std::optional> {
-
-        template <typename BinaryFunction, typename A, typename B>
-        static constexpr auto combine(std::optional<A> const &first, std::optional<B> const& second, BinaryFunction f) -> std::optional<decltype(f(std::declval<A>(), std::declval<B>()))> {
-            if (!first.has_value() || !second.has_value()) {
-                return {};
-            }
-            return f(first.value(), second.value());
-        }
-
-    };
-
-    template <>
     struct monad<std::optional> {
 
         template <typename UnaryFunction, typename A>
@@ -36,6 +23,19 @@ namespace rvarago::kitten {
     };
 
     template <>
+    struct applicative<std::optional> {
+
+        template <typename BinaryFunction, typename A, typename B>
+        static constexpr auto combine(std::optional<A> const &first, std::optional<B> const& second, BinaryFunction f) -> std::optional<decltype(f(std::declval<A>(), std::declval<B>()))> {
+            if (!first.has_value() || !second.has_value()) {
+                return {};
+            }
+            return f(first.value(), second.value());
+        }
+
+    };
+
+    template <>
     struct functor<std::optional> {
 
         template <typename UnaryFunction, typename A>
@@ -44,6 +44,11 @@ namespace rvarago::kitten {
         }
 
     };
+
+    namespace detail {
+        template <>
+        struct is_monad<std::optional> : std::true_type{};
+    }
 
 }
 

--- a/include/kitten/instances/optional.h
+++ b/include/kitten/instances/optional.h
@@ -48,6 +48,9 @@ namespace rvarago::kitten {
     namespace detail {
         template <>
         struct is_monad<std::optional> : std::true_type{};
+
+        template <>
+        struct is_functor<std::optional> : std::true_type{};
     }
 
 }

--- a/include/kitten/instances/sequence_container.h
+++ b/include/kitten/instances/sequence_container.h
@@ -10,6 +10,20 @@
 namespace rvarago::kitten {
 
     template <template <typename...> typename SequenceContainer>
+    struct monad<SequenceContainer> {
+
+        template <typename UnaryFunction, typename A, typename... Rest, typename = detail::traits::enable_if_sequence_container<SequenceContainer<A, Rest...>>>
+        static constexpr auto bind(SequenceContainer<A, Rest...> const& input, UnaryFunction f) -> decltype(f(std::declval<A>())) {
+            auto mapped_sequence = decltype(f(std::declval<A>())){};
+            for (auto const& el : input) {
+                ranges::copy(f(el), std::back_inserter(mapped_sequence));
+            }
+            return mapped_sequence;
+        }
+
+    };
+
+    template <template <typename...> typename SequenceContainer>
     struct applicative<SequenceContainer> {
 
         template <typename BinaryFunction, typename A, typename B, typename... Rest, typename = detail::traits::enable_if_sequence_container<SequenceContainer<A, Rest...>>>
@@ -27,20 +41,6 @@ namespace rvarago::kitten {
     };
 
     template <template <typename...> typename SequenceContainer>
-    struct monad<SequenceContainer> {
-
-        template <typename UnaryFunction, typename A, typename... Rest, typename = detail::traits::enable_if_sequence_container<SequenceContainer<A, Rest...>>>
-        static constexpr auto bind(SequenceContainer<A, Rest...> const& input, UnaryFunction f) -> decltype(f(std::declval<A>())) {
-            auto mapped_sequence = decltype(f(std::declval<A>())){};
-            for (auto const& el : input) {
-                ranges::copy(f(el), std::back_inserter(mapped_sequence));
-            }
-            return mapped_sequence;
-        }
-
-    };
-
-    template <template <typename...> typename SequenceContainer>
     struct functor<SequenceContainer> {
 
         template <typename UnaryFunction, typename A, typename... Rest, typename = detail::traits::enable_if_sequence_container<SequenceContainer<A, Rest...>>>
@@ -49,6 +49,11 @@ namespace rvarago::kitten {
         }
 
     };
+
+    namespace detail {
+        template <template <typename...> typename SequenceContainer>
+        struct is_monad<SequenceContainer> : std::true_type{};
+    }
 
 }
 

--- a/include/kitten/instances/sequence_container.h
+++ b/include/kitten/instances/sequence_container.h
@@ -12,7 +12,7 @@ namespace rvarago::kitten {
     template <template <typename...> typename SequenceContainer>
     struct monad<SequenceContainer> {
 
-        template <typename UnaryFunction, typename A, typename... Rest, typename = detail::traits::enable_if_sequence_container<SequenceContainer<A, Rest...>>>
+        template <typename UnaryFunction, typename A, typename... Rest, typename = detail::traits::enable_if_sequence_container<SequenceContainer>>
         static constexpr auto bind(SequenceContainer<A, Rest...> const& input, UnaryFunction f) -> decltype(f(std::declval<A>())) {
             auto mapped_sequence = decltype(f(std::declval<A>())){};
             for (auto const& el : input) {
@@ -26,7 +26,7 @@ namespace rvarago::kitten {
     template <template <typename...> typename SequenceContainer>
     struct applicative<SequenceContainer> {
 
-        template <typename BinaryFunction, typename A, typename B, typename... Rest, typename = detail::traits::enable_if_sequence_container<SequenceContainer<A, Rest...>>>
+        template <typename BinaryFunction, typename A, typename B, typename... Rest, typename = detail::traits::enable_if_sequence_container<SequenceContainer>>
         static constexpr auto combine(SequenceContainer<A, Rest...> const &first, SequenceContainer<B, Rest...> const& second, BinaryFunction f) -> SequenceContainer<decltype(f(std::declval<A>(), std::declval<B>()))> {
             using ValueT = decltype(f(std::declval<A>(), std::declval<B>()));
             auto combined_sequence = SequenceContainer<ValueT>{};
@@ -43,7 +43,7 @@ namespace rvarago::kitten {
     template <template <typename...> typename SequenceContainer>
     struct functor<SequenceContainer> {
 
-        template <typename UnaryFunction, typename A, typename... Rest, typename = detail::traits::enable_if_sequence_container<SequenceContainer<A, Rest...>>>
+        template <typename UnaryFunction, typename A, typename... Rest, typename = detail::traits::enable_if_sequence_container<SequenceContainer>>
         static constexpr auto map(SequenceContainer<A, Rest...> const& input, UnaryFunction f) -> SequenceContainer<decltype(f(std::declval<A>()))> {
             return monad<SequenceContainer>::bind(input, [&f](auto const& v) { return SequenceContainer{f(v)}; });
         }

--- a/include/kitten/instances/sequence_container.h
+++ b/include/kitten/instances/sequence_container.h
@@ -55,6 +55,9 @@ namespace rvarago::kitten {
         struct is_monad<SequenceContainer> : std::true_type{};
 
         template <template <typename...> typename SequenceContainer>
+        struct is_applicative<SequenceContainer> : std::true_type{};
+
+        template <template <typename...> typename SequenceContainer>
         struct is_functor<SequenceContainer> : std::true_type{};
     }
 

--- a/include/kitten/instances/sequence_container.h
+++ b/include/kitten/instances/sequence_container.h
@@ -53,6 +53,9 @@ namespace rvarago::kitten {
     namespace detail {
         template <template <typename...> typename SequenceContainer>
         struct is_monad<SequenceContainer> : std::true_type{};
+
+        template <template <typename...> typename SequenceContainer>
+        struct is_functor<SequenceContainer> : std::true_type{};
     }
 
 }

--- a/include/kitten/instances/variant.h
+++ b/include/kitten/instances/variant.h
@@ -29,6 +29,11 @@ namespace rvarago::kitten {
 
     };
 
+    namespace detail {
+        template <>
+        struct is_multifunctor<std::variant> : std::true_type{};
+    }
+
 }
 
 #endif

--- a/include/kitten/monad.h
+++ b/include/kitten/monad.h
@@ -1,6 +1,8 @@
 #ifndef RVARAGO_KITTEN_MONAD_H
 #define RVARAGO_KITTEN_MONAD_H
 
+#include <type_traits>
+
 namespace rvarago::kitten {
 
     /**
@@ -21,6 +23,14 @@ namespace rvarago::kitten {
     template <template <typename ...> typename M, typename = void>
     struct monad;
 
+    namespace detail {
+        template <template <typename ...> typename, typename = void>
+        struct is_monad : std::false_type{};
+
+        template <template <typename ...> typename M>
+        inline constexpr bool is_monad_v = is_monad<M>::value;
+    }
+
     /**
      * Forwards to the monad implementation.
      *
@@ -30,6 +40,7 @@ namespace rvarago::kitten {
      */
     template <typename UnaryFunction, template <typename ...> typename M, typename A, typename... Rest>
     constexpr decltype(auto) bind(M<A, Rest...> const& input, UnaryFunction f) {
+        static_assert(detail::is_monad_v<M>, "type constructor M does not have a monad instance");
         return monad<M>::bind(input, f);
     }
 

--- a/include/kitten/multifunctor.h
+++ b/include/kitten/multifunctor.h
@@ -12,6 +12,14 @@ namespace rvarago::kitten {
     template <template <typename ...> typename MF, typename = void>
     struct multifunctor;
 
+    namespace detail {
+        template <template <typename ...> typename, typename = void>
+        struct is_multifunctor : std::false_type{};
+
+        template <template <typename ...> typename MF>
+        inline constexpr bool is_multifunctor_v = is_multifunctor<MF>::value;
+    }
+
     /**
      * Forwards to the multifunctor implementation.
      *
@@ -21,6 +29,7 @@ namespace rvarago::kitten {
      */
     template <typename UnaryFunction, template <typename ...> typename MF, typename... Rest>
     constexpr decltype(auto) multimap(MF<Rest...> const& input, UnaryFunction f) {
+        static_assert(detail::is_multifunctor_v<MF>, "type constructor MF does not have a multifunctor instance");
         return multifunctor<MF>::multimap(input, f);
     }
 


### PR DESCRIPTION
Use static_assert to provide better compile-time error messages to clients when they try to use functors, multifunctors, applicatives, or monads for types that don't provide such instances.