### PR TITLE
Easier way to select the build type (Release/Debug) and rename the flag to build with tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,4 @@ services:
 
 script:
   - make env-test
-  - make env-conan-package WITH_TESTS=false PACKAGE_VERSION=ci
+  - make env-conan-package BUILD_TESTS=OFF PACKAGE_VERSION=ci

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,8 @@ project(kitten LANGUAGES CXX)
 
 # Definition
 
+option(BUILD_TESTS "Build test executable" ON)
+
 add_library(${PROJECT_NAME} INTERFACE)
 
 add_library(rvarago::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
@@ -46,7 +48,7 @@ export(EXPORT ${PROJECT_NAME}Config
 export(PACKAGE ${PROJECT_NAME})
 
 # Tests
-if(WITH_TESTS)
+if(BUILD_TESTS)
     include(CTest)
     add_subdirectory(tests)
 endif()

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,4 +6,4 @@ WORKDIR kitten
 
 COPY . .
 
-CMD ["make", "--no-print-directory"]
+CMD ["/bin/bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,4 +6,4 @@ WORKDIR kitten
 
 COPY . .
 
-CMD ["make", "test", "--no-print-directory"]
+CMD ["make", "--no-print-directory"]

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ env-test: env
 	docker run --rm ${PROJECT_NAME} make compile test --no-print-directory
 
 env-conan-package: env
-	docker run --rm ${PROJECT_NAME} make compile conan-package BUILD_TESTS=${BUILD_TESTS} PACKAGE_VERSION=${PACKAGE_VERSION} --no-print-directory
+	docker run --rm ${PROJECT_NAME} make compile conan-package BUILD_TYPE=${BUILD_TYPE} BUILD_TESTS=${BUILD_TESTS} PACKAGE_VERSION=${PACKAGE_VERSION} --no-print-directory
 
 install:
 	cd ${BUILD_DIR} && cmake --build . --target install

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ WITH_TESTS              = true
 PACKAGE_VERSION         =
 PACKAGE_REFERENCE       = ${PROJECT_NAME}/${PACKAGE_VERSION}@rvarago/stable
 BUILD_DIR               = build
+BUILD_TYPE              = Debug
 
 .PHONY: all conan-package env-conan-package test install compile gen dep mk clean env env-test
 
@@ -31,10 +32,10 @@ compile: gen
 	cd ${BUILD_DIR} && cmake --build .
 
 gen: dep
-	cd ${BUILD_DIR} && cmake -D WITH_TESTS=${WITH_TESTS} ..
+	cd ${BUILD_DIR} && cmake -D WITH_TESTS=${WITH_TESTS} -DCMAKE_BUILD_TYPE=${BUILD_TYPE} ..
 
 dep: mk
-	cd ${BUILD_DIR} && conan install .. --build=missing -pr ${PROFILE}
+	cd ${BUILD_DIR} && conan install .. --build=missing -pr ${PROFILE} -s build_type=${BUILD_TYPE}
 
 mk:
 	mkdir -p ${BUILD_DIR}

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 PROJECT_NAME            = kitten
 PROFILE                 = ../profiles/common
-WITH_TESTS              = true
 PACKAGE_VERSION         =
 PACKAGE_REFERENCE       = ${PROJECT_NAME}/${PACKAGE_VERSION}@rvarago/stable
 BUILD_DIR               = build
+BUILD_TESTS             = ON
 BUILD_TYPE              = Debug
 
 .PHONY: all conan-package env-conan-package test install compile gen dep mk clean env env-test
@@ -14,25 +14,25 @@ env:
 	docker build -t ${PROJECT_NAME} .
 
 env-test: env
-	docker run --rm ${PROJECT_NAME}
+	docker run --rm ${PROJECT_NAME} make compile test --no-print-directory
 
 env-conan-package: env
-	docker run --rm ${PROJECT_NAME} make conan-package WITH_TESTS=${WITH_TESTS} PACKAGE_VERSION=${PACKAGE_VERSION}
+	docker run --rm ${PROJECT_NAME} make compile conan-package BUILD_TESTS=${BUILD_TESTS} PACKAGE_VERSION=${PACKAGE_VERSION} --no-print-directory
 
-install: compile
+install:
 	cd ${BUILD_DIR} && cmake --build . --target install
 
-conan-package: compile
+conan-package:
 	conan create . ${PACKAGE_REFERENCE}
 
-test: compile
+test:
 	cd ${BUILD_DIR} && ctest -VV .
 
 compile: gen
 	cd ${BUILD_DIR} && cmake --build .
 
 gen: dep
-	cd ${BUILD_DIR} && cmake -D WITH_TESTS=${WITH_TESTS} -DCMAKE_BUILD_TYPE=${BUILD_TYPE} ..
+	cd ${BUILD_DIR} && cmake -D BUILD_TESTS=${BUILD_TESTS} -DCMAKE_BUILD_TYPE=${BUILD_TYPE} ..
 
 dep: mk
 	cd ${BUILD_DIR} && conan install .. --build=missing -pr ${PROFILE} -s build_type=${BUILD_TYPE}

--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ The _Makefile_ wraps the commands to download dependencies (Conan), generate the
 unit tests, and clear the build folder. Please consult the Makefile to adapt
 the commands in case you want to build _absent_ directly without using make.
 
-* Compile (by default, it also compiles the unit tests):
+* Compile:
 
 ``
 make
@@ -263,7 +263,7 @@ make
 By default, it also builds the unit tests, you can disable the behavior by:
 
 ``
-make WITH_TESTS=false
+make BUILD_TESTS=OFF
 ``
 
 
@@ -280,7 +280,7 @@ And to build with Release mode (by default it builds with Debug mode enabled):
 make BUILD_TYPE=Release
 ``
 
-* To run the unit tests:
+* To run the unit tests, if previously compiled:
 
 ``
 make test

--- a/README.md
+++ b/README.md
@@ -251,7 +251,8 @@ returns `either<B, E>`.
 ## Build
 
 The _Makefile_ wraps the commands to download dependencies (Conan), generate the build configuration, build, run the
-unit tests, and clear the build folder.
+unit tests, and clear the build folder. Please consult the Makefile to adapt
+the commands in case you want to build _absent_ directly without using make.
 
 * Compile (by default, it also compiles the unit tests):
 
@@ -271,6 +272,12 @@ can specify your profile by setting _PROFILE_ as:
 
 ``
 make PROFILE=<path_to_your_profile>
+``
+
+And to build with Release mode (by default it builds with Debug mode enabled):
+
+``
+make BUILD_TYPE=Release
 ``
 
 * To run the unit tests:

--- a/profiles/common
+++ b/profiles/common
@@ -2,7 +2,6 @@
 compiler=gcc
 compiler.version=8
 compiler.libcxx=libstdc++11
-build_type=Release
 os=Linux
 os_build=Linux
 arch=x86_64


### PR DESCRIPTION
- The option BUILD_TYPE which can be Release and Debug, and it defaults to Debug is now added.
- The flag WITH_TESTS is renamed to BUILD_TESTS and added as a CMake option (ON/OFF) to build with tests or not, and it defaults to ON.