### PR TITLE
feature: Add new adapter for function composition using fmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,18 +222,26 @@ Note that it's possible that a type may not admit instances for all the structur
 
 The following types are currently supported:
 
-|         Type         | Functor | Applicative | Monad | Multi-functor |
-|:--------------------:|:-------:|-------------|-------|:-------------:|
-|    `either<A, E>`    |    x    |     x       | x     |               |
-|  `std::optional<T>`  |    x    |     x       | x     |               |
-|    `std::deque<T>`   |    x    |     x       | x     |               |
-|    `std::list<T>`    |    x    |     x       | x     |               |
-| `std::variant<T...>` |         |             |       |       x       |
-|   `std::vector<T>`   |    x    |     x       |       |               |
+|         Type                      | Functor | Applicative | Monad   | Multi-functor |
+|:---------------------------------:|:-------:|-------------|---------|:-------------:|
+| `types::either<A, E>`             |    x    |     x       |   x     |               |
+| `types::function_wrapper<F>`      |    x    |             |         |               |
+| `std::optional<T>`                |    x    |     x       |   x     |               |
+| `std::deque<T>`                   |    x    |     x       |   x     |               |
+| `std::list<T>`                    |    x    |     x       |   x     |               |
+| `std::variant<T...>`              |         |             |         |       x       |
+| `std::vector<T>`                  |    x    |     x       |         |               |
 
-- `either<A, E>` is a *left-biased* alias for `std::variant<A, E>`. And by left-biased, I mean that the mapping only
+- `types::either<A, E>` is a *left-biased* alias for `std::variant<A, E>`. And by left-biased, I mean that the mapping only
 happens for the left type parameter `A`. For instance `fmap` receives a function `f: A -> B` and then
-returns `either<B, E>`.
+returns `types::either<B, E>`.
+- `types::function_wrapper<F>` is a callable wrapper around a function-like type, e.g. function, function object, etc.
+And it allows using `fmap` to compose functions, e.g. given `fx : A -> B` and
+`fy: B -> C`, and both wrapped around `types::function_wrapper` which can conveniently be done
+by the helper function `types::fn`, then `fmap(fx, fy)` returns a new `types::function_wrapper`
+ `fz: A -> C` that applies `fx` and then `fy`. So, by providing an argument
+ `x` of type `A`, we have: `fmap(fx, fy)(x) == fy(fx(x))`.
+
 
 ## Requirements
 

--- a/include/kitten/instances/function.h
+++ b/include/kitten/instances/function.h
@@ -1,0 +1,58 @@
+#ifndef RVARAGO_KITTEN_FUNCTION_H
+#define RVARAGO_KITTEN_FUNCTION_H
+
+#include "kitten/functor.h"
+
+#include <utility>
+
+namespace rvarago::kitten {
+
+    namespace types {
+
+        template <typename Function>
+        class function_wrapper {
+            Function const f;
+        public:
+            explicit constexpr function_wrapper(Function const invokable) noexcept : f{invokable} {}
+
+            template <typename... Args>
+            constexpr auto operator()(Args&&... args) const noexcept -> decltype(f(std::forward<Args>(args)...)) {
+                return f(std::forward<Args>(args)...);
+            }
+        };
+
+        template <typename Function>
+        constexpr function_wrapper<Function> fn(Function const invokable) {
+            return function_wrapper{invokable};
+        }
+
+    }
+
+    template <>
+    struct functor<types::function_wrapper> {
+
+        /**
+         * Composes the functions first and second, in such a way that the result of the first feeds the second, i.e:
+         *  fmap(first, second)(x) = second(fist(second))
+         *
+         * @param first a function A -> B to applied when the argument A are provided
+         * @param second function B -> C to be applied with the result from previous application of first
+         * @return a function composition A -> C that, when its argument is provided, applied first and then second
+         */
+        template <typename UnaryFunctionA, typename UnaryFunctionB>
+        static constexpr decltype(auto) fmap(types::function_wrapper<UnaryFunctionA> const &first, types::function_wrapper<UnaryFunctionB> const& second) {
+            return types::fn([first, second](auto&&... args) {
+                return second(first(std::forward<decltype(args)>(args)...));
+            });
+        }
+
+    };
+
+    namespace traits {
+        template <>
+        struct is_functor<types::function_wrapper> : std::true_type{};
+    }
+
+}
+
+#endif

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4,6 +4,7 @@ set(CMAKE_MODULE_PATH ${CMAKE_BINARY_DIR})
 
 add_executable(${PROJECT_NAME}
         either_test.cpp
+        function_test.cpp
         optional_test.cpp
         main.cpp
         sequence_container_test.cpp

--- a/tests/function_test.cpp
+++ b/tests/function_test.cpp
@@ -1,0 +1,34 @@
+#include <gtest/gtest.h>
+
+#include <string>
+#include <kitten/instances/function.h>
+
+namespace {
+
+    using namespace rvarago::kitten;
+
+    using namespace std::string_literals;
+    using namespace rvarago::kitten;
+    using namespace rvarago::kitten::types;
+
+    char void_to_char() {
+        return 'x';
+    }
+
+    int char_to_int(char) {
+        return 42;
+    }
+
+    std::string int_to_string(int) {
+        return "10"s;
+    }
+
+    TEST(function, map_should_returnTheFunctionsComposition) {
+        auto const char_to_string = fn(char_to_int) | fn(int_to_string);
+        auto const void_to_string = fn(void_to_char) | fn(char_to_int) | fn(int_to_string);
+
+        EXPECT_EQ("10"s, char_to_string('x'));
+        EXPECT_EQ("10"s, void_to_string());
+    }
+
+}


### PR DESCRIPTION
The wrapper type: types::function_wrapper, which can be built via
helper function fn, allows the usual composition with fmap to be
applied to functions as well.

So, given functions fx: A -> B and fy: B -> C, by wrapping both
around types::function_wrapper, we can fmap(fx, fy) that composes
fx and fy, so by providing an argument x of type A, we have:

fmap(fx, fy)(x) == fy(fx(x))