### PR TITLE
Implement Applicative and Functor in terms of a Monad instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,9 @@ Hence, we can do:
 
 `bind(f(), g)`
 
+In addition, a monad also has a function `wrap(A): X<A>` that allows one to lift a value
+of type `A` into a monad `X<A>`.
+
 Using _kitten_, one example of using a monad is:
 
 ```

--- a/include/kitten/detail/deriving/from_monad/derive_applicative.h
+++ b/include/kitten/detail/deriving/from_monad/derive_applicative.h
@@ -1,0 +1,21 @@
+#ifndef RVARAGO_KITTEN_DERIVE_APPLICATIVE_H
+#define RVARAGO_KITTEN_DERIVE_APPLICATIVE_H
+
+#include "kitten/applicative.h"
+#include "kitten/monad.h"
+
+namespace rvarago::kitten::detail::deriving {
+
+    template <typename BinaryFunction, template <typename ...> typename M, typename A, typename B, typename... Rest>
+    constexpr auto combine(M<A, Rest...> const &first, M<B, Rest...> const& second, BinaryFunction f) -> M<decltype(f(std::declval<A>(), std::declval<B>()))> {
+        using MonadT = monad<M>;
+        return MonadT::bind(first, [&second, f](auto const& first_value) {
+            return MonadT::bind(second, [&first_value, f](auto const& second_value) {
+                return MonadT::wrap(f(first_value, second_value));
+            });
+        });
+    }
+
+}
+
+#endif

--- a/include/kitten/detail/deriving/from_monad/derive_functor.h
+++ b/include/kitten/detail/deriving/from_monad/derive_functor.h
@@ -1,0 +1,19 @@
+#ifndef RVARAGO_KITTEN_DERIVE_FUNCTOR_H
+#define RVARAGO_KITTEN_DERIVE_FUNCTOR_H
+
+#include "kitten/functor.h"
+#include "kitten/monad.h"
+
+namespace rvarago::kitten::detail::deriving {
+
+    template <typename UnaryFunction,template <typename ...> typename M, typename A, typename... Rest>
+    constexpr decltype(auto) fmap(M<A, Rest...> const& input, UnaryFunction f) {
+        using MonadT = monad<M>;
+        return MonadT::bind(input, [&f](auto const& value) {
+            return MonadT::wrap(f(value));
+        });
+    }
+
+}
+
+#endif

--- a/include/kitten/instances/either.h
+++ b/include/kitten/instances/either.h
@@ -26,6 +26,11 @@ namespace rvarago::kitten {
             return f(std::get<A>(input));
         }
 
+        template <typename A, typename E>
+        static constexpr auto wrap(A&& value) -> std::variant<A, E> {
+            return std::variant<A, E>(std::forward<A>(value));
+        }
+
     };
 
     template <>
@@ -51,7 +56,8 @@ namespace rvarago::kitten {
 
         template <typename UnaryFunction, typename A, typename E>
         static constexpr auto fmap(std::variant<A, E> const &input, UnaryFunction f) -> std::variant<decltype(f(std::declval<A>())), E> {
-            return monad<std::variant>::bind(input, [&f](auto const& value){ return std::variant<decltype(f(std::declval<A>())), E>{f(value)}; });
+            using MonadT = monad<std::variant>;
+            return MonadT::bind(input, [&f](auto const& value){ return MonadT::wrap<decltype(f(std::declval<A>())), E>(f(value)); });
         }
 
     };

--- a/include/kitten/instances/optional.h
+++ b/include/kitten/instances/optional.h
@@ -7,6 +7,9 @@
 #include "kitten/functor.h"
 #include "kitten/monad.h"
 
+#include "kitten/detail/deriving/from_monad/derive_applicative.h"
+#include "kitten/detail/deriving/from_monad/derive_functor.h"
+
 namespace rvarago::kitten {
 
     template <>
@@ -32,12 +35,7 @@ namespace rvarago::kitten {
 
         template <typename BinaryFunction, typename A, typename B>
         static constexpr auto combine(std::optional<A> const &first, std::optional<B> const& second, BinaryFunction f) -> std::optional<decltype(f(std::declval<A>(), std::declval<B>()))> {
-            using MonadT = monad<std::optional>;
-            return MonadT::bind(first, [&second, &f](auto const& first_value) {
-                return MonadT::bind(second, [&first_value, &f](auto const& second_value) {
-                    return MonadT::wrap(f(first_value, second_value));
-                });
-            });
+            return detail::deriving::combine(first, second, f);
         }
 
     };
@@ -47,8 +45,7 @@ namespace rvarago::kitten {
 
         template <typename UnaryFunction, typename A>
         static constexpr auto fmap(std::optional<A> const &input, UnaryFunction f) -> std::optional<decltype(f(std::declval<A>()))> {
-            using MonadT = monad<std::optional>;
-            return MonadT::bind(input, [&f](auto const& value){ return MonadT::wrap(f(value)); });
+            return detail::deriving::fmap(input, f);
         }
 
     };

--- a/include/kitten/instances/optional.h
+++ b/include/kitten/instances/optional.h
@@ -20,6 +20,11 @@ namespace rvarago::kitten {
             return f(*input);
         }
 
+        template <typename A>
+        static constexpr auto wrap(A&& value) -> std::optional<A> {
+            return std::make_optional(std::forward<A>(value));
+        }
+
     };
 
     template <>
@@ -40,7 +45,8 @@ namespace rvarago::kitten {
 
         template <typename UnaryFunction, typename A>
         static constexpr auto fmap(std::optional<A> const &input, UnaryFunction f) -> std::optional<decltype(f(std::declval<A>()))> {
-            return monad<std::optional>::bind(input, [&f](auto const& value){ return std::optional{f(value)}; });
+            using MonadT = monad<std::optional>;
+            return MonadT::bind(input, [&f](auto const& value){ return MonadT::wrap(f(value)); });
         }
 
     };

--- a/include/kitten/instances/optional.h
+++ b/include/kitten/instances/optional.h
@@ -32,10 +32,12 @@ namespace rvarago::kitten {
 
         template <typename BinaryFunction, typename A, typename B>
         static constexpr auto combine(std::optional<A> const &first, std::optional<B> const& second, BinaryFunction f) -> std::optional<decltype(f(std::declval<A>(), std::declval<B>()))> {
-            if (!first || !second) {
-                return std::nullopt;
-            }
-            return f(*first, *second);
+            using MonadT = monad<std::optional>;
+            return MonadT::bind(first, [&second, &f](auto const& first_value) {
+                return MonadT::bind(second, [&first_value, &f](auto const& second_value) {
+                    return MonadT::wrap(f(first_value, second_value));
+                });
+            });
         }
 
     };

--- a/include/kitten/instances/sequence_container.h
+++ b/include/kitten/instances/sequence_container.h
@@ -9,6 +9,10 @@
 #include "kitten/applicative.h"
 #include "kitten/functor.h"
 #include "kitten/monad.h"
+
+#include "kitten/detail/deriving/from_monad/derive_applicative.h"
+#include "kitten/detail/deriving/from_monad/derive_functor.h"
+
 #include "kitten/ranges/algorithm.h"
 
 namespace rvarago::kitten {
@@ -57,12 +61,7 @@ namespace rvarago::kitten {
 
         template <typename BinaryFunction, typename A, typename B, typename... Rest, typename = detail::enable_if_sequence_container<SequenceContainer>>
         static constexpr auto combine(SequenceContainer<A, Rest...> const &first, SequenceContainer<B, Rest...> const& second, BinaryFunction f) -> SequenceContainer<decltype(f(std::declval<A>(), std::declval<B>()))> {
-            using MonadT = monad<SequenceContainer>;
-            return MonadT::bind(first, [&second, &f](auto const& first_value) {
-                return MonadT::bind(second, [&first_value, &f](auto const& second_value) {
-                    return MonadT::wrap(f(first_value, second_value));
-                });
-            });
+            return detail::deriving::combine(first, second, f);
         }
 
     };
@@ -72,8 +71,7 @@ namespace rvarago::kitten {
 
         template <typename UnaryFunction, typename A, typename... Rest, typename = detail::enable_if_sequence_container<SequenceContainer>>
         static constexpr auto fmap(SequenceContainer<A, Rest...> const& input, UnaryFunction f) -> SequenceContainer<decltype(f(std::declval<A>()))> {
-            using MonadT = monad<SequenceContainer>;
-            return MonadT::bind(input, [&f](auto const& v) { return MonadT::wrap(f(v)); });
+            return detail::deriving::fmap(input, f);
         }
 
     };

--- a/include/kitten/instances/sequence_container.h
+++ b/include/kitten/instances/sequence_container.h
@@ -57,14 +57,12 @@ namespace rvarago::kitten {
 
         template <typename BinaryFunction, typename A, typename B, typename... Rest, typename = detail::enable_if_sequence_container<SequenceContainer>>
         static constexpr auto combine(SequenceContainer<A, Rest...> const &first, SequenceContainer<B, Rest...> const& second, BinaryFunction f) -> SequenceContainer<decltype(f(std::declval<A>(), std::declval<B>()))> {
-            using ValueT = decltype(f(std::declval<A>(), std::declval<B>()));
-            auto combined_sequence = SequenceContainer<ValueT>{};
-            for (auto const& first_element : first) {
-                for (auto const& second_element: second) {
-                    combined_sequence.push_back(f(first_element, second_element));
-                }
-            }
-            return combined_sequence;
+            using MonadT = monad<SequenceContainer>;
+            return MonadT::bind(first, [&second, &f](auto const& first_value) {
+                return MonadT::bind(second, [&first_value, &f](auto const& second_value) {
+                    return MonadT::wrap(f(first_value, second_value));
+                });
+            });
         }
 
     };

--- a/include/kitten/instances/sequence_container.h
+++ b/include/kitten/instances/sequence_container.h
@@ -45,6 +45,11 @@ namespace rvarago::kitten {
             return mapped_sequence;
         }
 
+        template <typename A, typename... Rest, typename = detail::enable_if_sequence_container<SequenceContainer>>
+        static constexpr auto wrap(A&& value, Rest&&... tail) -> SequenceContainer<A, Rest...> {
+            return SequenceContainer<A, Rest...>{std::forward<A>(value), std::forward<Rest>(tail)...};
+        }
+
     };
 
     template <template <typename...> typename SequenceContainer>
@@ -69,7 +74,8 @@ namespace rvarago::kitten {
 
         template <typename UnaryFunction, typename A, typename... Rest, typename = detail::enable_if_sequence_container<SequenceContainer>>
         static constexpr auto fmap(SequenceContainer<A, Rest...> const& input, UnaryFunction f) -> SequenceContainer<decltype(f(std::declval<A>()))> {
-            return monad<SequenceContainer>::bind(input, [&f](auto const& v) { return SequenceContainer{f(v)}; });
+            using MonadT = monad<SequenceContainer>;
+            return MonadT::bind(input, [&f](auto const& v) { return MonadT::wrap(f(v)); });
         }
 
     };

--- a/include/kitten/monad.h
+++ b/include/kitten/monad.h
@@ -32,6 +32,19 @@ namespace rvarago::kitten {
     }
 
     /**
+     * Lifts a value of type A into a monad M[A].
+     *
+     * @param value the type parameter that defines the type of the element wrapped by the monad
+     * @param tail eventual remaining type parameters used by the monad, considered as implementation detail
+     * @return a new monad m: M[A] that wraps the contained value of type A
+     */
+    template <template <typename ...> typename M, typename A, typename... Rest>
+    constexpr decltype(auto) wrap(A&& value) {
+        static_assert(traits::is_monad_v<M>, "type constructor M does not have a monad instance");
+        return monad<M>::template wrap<A, Rest...>(std::forward<A>(value));
+    }
+
+    /**
      * Forwards to the monad implementation.
      *
      * @param input a monad ma: M[A]

--- a/tests/either_test.cpp
+++ b/tests/either_test.cpp
@@ -74,6 +74,15 @@ namespace {
         EXPECT_EQ("6", std::get<std::string>(product_as_string));
     }
 
+    TEST(either, wrap_should_returnANonEmptyMonad) {
+        auto const value_one = wrap<std::variant, int, error_t>(1);
+
+        static_assert(is_same_after_decaying<types::either<int, error_t>, decltype(value_one)>);
+
+        EXPECT_TRUE(std::holds_alternative<int>(value_one));
+        EXPECT_EQ(1, std::get<int>(value_one));
+    }
+
     TEST(either, bind_should_returnEmpty_when_empty) {
         auto const error = types::either<int, error_t>{error_t{-1}};
         auto const mapped_error = error >> [](auto v){ return types::either<std::string, error_t>{std::to_string(v * 10)}; };

--- a/tests/optional_test.cpp
+++ b/tests/optional_test.cpp
@@ -63,6 +63,15 @@ namespace {
         EXPECT_EQ("6", product_as_string.value());
     }
 
+    TEST(optional, wrap_should_returnANonEmptyMonad) {
+        auto const some_one = wrap<std::optional>(1);
+
+        static_assert(is_same_after_decaying<std::optional<int>, decltype(some_one)>);
+
+        EXPECT_TRUE(some_one.has_value());
+        EXPECT_EQ(1, some_one.value());
+    }
+
     TEST(optional, bind_should_returnEmpty_when_empty) {
         auto const none = std::optional<int>{};
         auto const mapped_none = none >> [](auto v){ return std::optional{std::to_string(v * 10)}; };

--- a/tests/sequence_container_test.cpp
+++ b/tests/sequence_container_test.cpp
@@ -18,6 +18,7 @@ namespace {
         using type = T;
     };
 
+    // TODO: Generalize the tests to support template template parameter
     using sequence_containers = ::testing::Types<std::deque<int>, std::list<int>, std::vector<int>>;
 
     TYPED_TEST_CASE(SequenceContainerTest, sequence_containers);
@@ -86,6 +87,28 @@ namespace {
         EXPECT_EQ("60", value_at(product_as_string, 1));
         EXPECT_EQ("60", value_at(product_as_string, 2));
         EXPECT_EQ("90", value_at(product_as_string, 3));
+    }
+
+    TEST(deque, wrap_should_returnANonEmptyMonad) {
+        // FIXME: Test for all the other containers
+        auto const singleton = wrap<std::deque>(1);
+
+        EXPECT_TRUE(!singleton.empty());
+        EXPECT_EQ(1, value_at(singleton, 0));
+    }
+
+    TEST(vector, wrap_should_returnANonEmptyMonad) {
+        auto const singleton = wrap<std::vector>(1);
+
+        EXPECT_TRUE(!singleton.empty());
+        EXPECT_EQ(1, value_at(singleton, 0));
+    }
+
+    TEST(list, wrap_should_returnANonEmptyMonad) {
+        auto const singleton = wrap<std::list>(1);
+
+        EXPECT_TRUE(!singleton.empty());
+        EXPECT_EQ(1, value_at(singleton, 0));
     }
 
     TYPED_TEST(SequenceContainerTest, bind_should_returnEmpty_when_empty) {


### PR DESCRIPTION
* refactor: Implement generic applicative's combine and functor's fmap
* refactor: Implement Applicative combine in terms of Monad bind/wrap
* feature: Add function wrap to lift a value of type T into a monad M[T]