### PR TITLE
change: Use operator>>= instead of operator>> for infix bind

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ of type `A` into a monad `X<A>`.
 Using _kitten_, one example of using a monad is:
 
 ```
-auto const maybe_name = maybe_find_person() >> maybe_get_name; // or bind(maybe_find_person(), maybe_get_name)
+auto const maybe_name = maybe_find_person() >>= maybe_get_name; // or bind(maybe_find_person(), maybe_get_name)
 ```
 
 Where `maybe_find_person` returns an `std::optional<person>`, and then the wrapped object of type `person` is fed into
@@ -216,7 +216,7 @@ Also, to simplify notation, they also come as overloaded operators that enable a
 
 - `|` as an alias for `fmap`
 - `+` as an alias for `combine`
-- `>>` as an alias for `bind`
+- `>>=` as an alias for `bind`
 - `||` as an alias for `multimap`
 
 The combinators are available conveniently in the header: `kitten/kitten.h`, or by importing each one separately. And

--- a/include/kitten/monad.h
+++ b/include/kitten/monad.h
@@ -61,7 +61,7 @@ namespace rvarago::kitten {
      * Infix version of bind.
      */
     template <typename UnaryFunction, template <typename ...> typename M, typename A, typename... Rest>
-    constexpr decltype(auto) operator>>(M<A, Rest...> const& input, UnaryFunction f) {
+    constexpr decltype(auto) operator>>=(M<A, Rest...> const& input, UnaryFunction f) {
         return bind(input, f);
     }
 

--- a/tests/optional_test.cpp
+++ b/tests/optional_test.cpp
@@ -83,7 +83,7 @@ namespace {
 
     TEST(optional, bind_should_returnEmpty_when_empty) {
         auto const none = std::optional<int>{};
-        auto const mapped_none = none >> [](auto v){ return std::optional{std::to_string(v * 10)}; };
+        auto const mapped_none = none >>= [](auto v){ return std::optional{std::to_string(v * 10)}; };
 
         static_assert(is_same_after_decaying<std::optional<std::string>, decltype(mapped_none)>);
 
@@ -92,7 +92,7 @@ namespace {
 
     TEST(optional, bind_should_returnMapped_when_notEmpty) {
         auto const some_one = std::optional<int>{1};
-        auto const mapped_some = some_one >> [](auto v){ return std::optional{std::to_string(v * 10)}; };
+        auto const mapped_some = some_one >>= [](auto v){ return std::optional{std::to_string(v * 10)}; };
 
         static_assert(is_same_after_decaying<std::optional<std::string>, decltype(mapped_some)>);
 

--- a/tests/sequence_container_test.cpp
+++ b/tests/sequence_container_test.cpp
@@ -138,7 +138,7 @@ namespace {
         using T  = typename TestFixture::type;
 
         auto const empty = T{};
-        auto const mapped_empty = empty >> [](auto v){ return std::vector{std::to_string(v * 10), std::to_string(v * 100)}; };
+        auto const mapped_empty = empty >>= [](auto v){ return std::vector{std::to_string(v * 10), std::to_string(v * 100)}; };
 
         EXPECT_TRUE(mapped_empty.empty());
     }
@@ -147,7 +147,7 @@ namespace {
         using T  = typename TestFixture::type;
 
         auto const container = T{1, 2};
-        auto const mapped_container = container >> [](auto v){ return std::vector{std::to_string(v * 10), std::to_string(v * 100)}; };
+        auto const mapped_container = container >>= [](auto v){ return std::vector{std::to_string(v * 10), std::to_string(v * 100)}; };
 
         EXPECT_TRUE(!mapped_container.empty());
         EXPECT_EQ(4, mapped_container.size());


### PR DESCRIPTION
Because operator>> can lead to confusion given that it's commonly used for streams.