### PR TITLE
refactor: Rename deriving applicative wrap to pure

### DIFF
--- a/include/kitten/detail/deriving/from_monad/derive_applicative.h
+++ b/include/kitten/detail/deriving/from_monad/derive_applicative.h
@@ -17,7 +17,7 @@ namespace rvarago::kitten::detail::deriving {
     }
 
     template <template <typename ...> typename M, typename A>
-    constexpr auto wrap(A&& value) -> M<A> {
+    constexpr auto pure(A&& value) -> M<A> {
         using MonadT = monad<M>;
         return MonadT::wrap(std::forward<A>(value));
     }

--- a/include/kitten/instances/optional.h
+++ b/include/kitten/instances/optional.h
@@ -40,7 +40,7 @@ namespace rvarago::kitten {
 
         template <typename A>
         static constexpr auto pure(A&& value) -> std::optional<A> {
-            return detail::deriving::wrap<std::optional>(std::forward<A>(value));
+            return detail::deriving::pure<std::optional>(std::forward<A>(value));
         }
 
     };

--- a/include/kitten/instances/sequence_container.h
+++ b/include/kitten/instances/sequence_container.h
@@ -66,7 +66,7 @@ namespace rvarago::kitten {
 
         template <typename A, typename = detail::enable_if_sequence_container<SequenceContainer>>
         static constexpr auto pure(A&& value) -> SequenceContainer<A> {
-            return detail::deriving::wrap<SequenceContainer>(std::forward<A>(value));
+            return detail::deriving::pure<SequenceContainer>(std::forward<A>(value));
         }
 
     };


### PR DESCRIPTION
Since it's the adopted name for applicative in kitten.