### PR TITLE
Add new combinator for functor instances: liftF

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,10 @@ Where `maybe_find_person` returns an `std::optional<person>`, and then the wrapp
 
 Thus, the result of the whole composition is of type `std::optional<name>`.
 
+An equivalent way to define a functor is by providing the function `liftF`,
+which maps a function `w: A -> B` into another function `z: X[A] -> X[B]`,
+where `X[T]` is a functor.
+
 ### Applicatives
 
 What happens if `f` takes several arguments? For instance, we have the objects `xa: X<A>` and `xb: X<B>` and the

--- a/include/kitten/applicative.h
+++ b/include/kitten/applicative.h
@@ -45,7 +45,7 @@ constexpr decltype(auto) pure(A &&value) {
  * @param f a function A -> A -> B that maps over the values wrapped inside apa1 and apa2 to yield a value b: B
  * @return a new applicative apb: AP[B] resulting from applying f over the wrapped value inside apa1 and apa2
  */
-template <typename BinaryFunction, template <typename...> typename AP, typename A, typename B>
+template <template <typename...> typename AP, typename A, typename B, typename BinaryFunction>
 constexpr decltype(auto) combine(AP<A> const &first, AP<B> const &second, BinaryFunction f) {
     static_assert(traits::is_applicative_v<AP>, "type constructor AP does not have an applicative instance");
     return applicative<AP>::combine(first, second, f);
@@ -54,7 +54,7 @@ constexpr decltype(auto) combine(AP<A> const &first, AP<B> const &second, Binary
 /**
  * Infix version of combine. Since operator+ expects two arguments, we had to wrap the applicatives in a tuple.
  */
-template <typename BinaryFunction, template <typename...> typename AP, typename A, typename B>
+template <template <typename...> typename AP, typename A, typename B, typename BinaryFunction>
 constexpr decltype(auto) operator+(std::tuple<AP<A>, AP<B>> const &input, BinaryFunction f) {
     return combine(std::get<0>(input), std::get<1>(input), f);
 }

--- a/include/kitten/detail/deriving/from_monad/derive_applicative.h
+++ b/include/kitten/detail/deriving/from_monad/derive_applicative.h
@@ -6,7 +6,7 @@
 
 namespace rvarago::kitten::detail::deriving {
 
-template <typename BinaryFunction, template <typename...> typename M, typename A, typename B>
+template <template <typename...> typename M, typename A, typename B, typename BinaryFunction>
 constexpr auto combine(M<A> const &first, M<B> const &second, BinaryFunction f)
     -> M<decltype(f(std::declval<A>(), std::declval<B>()))> {
     using MonadT = monad<M>;

--- a/include/kitten/detail/deriving/from_monad/derive_functor.h
+++ b/include/kitten/detail/deriving/from_monad/derive_functor.h
@@ -6,7 +6,7 @@
 
 namespace rvarago::kitten::detail::deriving {
 
-template <typename UnaryFunction, template <typename...> typename M, typename A>
+template <template <typename...> typename M, typename A, typename UnaryFunction>
 constexpr decltype(auto) fmap(M<A> const &input, UnaryFunction f) {
     using MonadT = monad<M>;
     return MonadT::bind(input, [&f](auto const &value) { return MonadT::wrap(f(value)); });

--- a/include/kitten/functor.h
+++ b/include/kitten/functor.h
@@ -32,7 +32,7 @@ inline constexpr bool is_functor_v = is_functor<F>::value;
  * @param f a function A -> B that maps over the value wrapped inside fa to yield a value b: B
  * @return a new functor fb: F[B] resulting from applying f over the wrapped value inside fa
  */
-template <typename UnaryFunction, template <typename...> typename F, typename A>
+template <template <typename...> typename F, typename A, typename UnaryFunction>
 constexpr decltype(auto) fmap(F<A> const &input, UnaryFunction f) {
     static_assert(traits::is_functor_v<F>, "type constructor F does not have a functor instance");
     return functor<F>::fmap(input, f);
@@ -41,7 +41,7 @@ constexpr decltype(auto) fmap(F<A> const &input, UnaryFunction f) {
 /**
  * Infix version of fmap.
  */
-template <typename UnaryFunction, template <typename...> typename F, typename A>
+template <template <typename...> typename F, typename A, typename UnaryFunction>
 constexpr decltype(auto) operator|(F<A> const &input, UnaryFunction f) {
     return fmap(input, f);
 }

--- a/include/kitten/functor.h
+++ b/include/kitten/functor.h
@@ -45,6 +45,18 @@ template <template <typename...> typename F, typename A, typename UnaryFunction>
 constexpr decltype(auto) operator|(F<A> const &input, UnaryFunction f) {
     return fmap(input, f);
 }
+
+/**
+ * Lifts a function A -> B into a function F[A] -> F[B], where F[_] is a functor.
+ *
+ * @param f a function A -> B that shall be applied to the content of F[A] where it's later provided
+ * @return a lifted function F[A] -> F[B]
+ */
+template <template <typename...> typename F, typename UnaryFunction>
+constexpr decltype(auto) liftF(UnaryFunction f) {
+    return [f](auto const &input) { return functor<F>::fmap(input, f); };
+}
+
 }
 
 #endif

--- a/include/kitten/instances/optional.h
+++ b/include/kitten/instances/optional.h
@@ -15,7 +15,7 @@ namespace rvarago::kitten {
 template <>
 struct monad<std::optional> {
 
-    template <typename UnaryFunction, typename A>
+    template <typename A, typename UnaryFunction>
     static constexpr auto bind(std::optional<A> const &input, UnaryFunction f) -> decltype(f(std::declval<A>())) {
         if (!input) {
             return std::nullopt;
@@ -32,7 +32,7 @@ struct monad<std::optional> {
 template <>
 struct applicative<std::optional> {
 
-    template <typename BinaryFunction, typename A, typename B>
+    template <typename A, typename B, typename BinaryFunction>
     static constexpr auto combine(std::optional<A> const &first, std::optional<B> const &second, BinaryFunction f)
         -> std::optional<decltype(f(std::declval<A>(), std::declval<B>()))> {
         return detail::deriving::combine(first, second, f);
@@ -47,7 +47,7 @@ struct applicative<std::optional> {
 template <>
 struct functor<std::optional> {
 
-    template <typename UnaryFunction, typename A>
+    template <typename A, typename UnaryFunction>
     static constexpr auto fmap(std::optional<A> const &input, UnaryFunction f)
         -> std::optional<decltype(f(std::declval<A>()))> {
         return detail::deriving::fmap(input, f);

--- a/include/kitten/instances/sequence_container.h
+++ b/include/kitten/instances/sequence_container.h
@@ -40,7 +40,7 @@ using enable_if_sequence_container = typename std::enable_if_t<is_sequence_conta
 template <template <typename...> typename SequenceContainer>
 struct monad<SequenceContainer> {
 
-    template <typename UnaryFunction, typename A, typename = detail::enable_if_sequence_container<SequenceContainer>>
+    template <typename A, typename UnaryFunction, typename = detail::enable_if_sequence_container<SequenceContainer>>
     static constexpr auto bind(SequenceContainer<A> const &input, UnaryFunction f) -> decltype(f(std::declval<A>())) {
         auto mapped_sequence = decltype(f(std::declval<A>())){};
         for (auto const &el : input) {
@@ -58,7 +58,7 @@ struct monad<SequenceContainer> {
 template <template <typename...> typename SequenceContainer>
 struct applicative<SequenceContainer> {
 
-    template <typename BinaryFunction, typename A, typename B,
+    template <typename A, typename B, typename BinaryFunction,
               typename = detail::enable_if_sequence_container<SequenceContainer>>
     static constexpr auto combine(SequenceContainer<A> const &first, SequenceContainer<B> const &second,
                                   BinaryFunction f)
@@ -75,7 +75,7 @@ struct applicative<SequenceContainer> {
 template <template <typename...> typename SequenceContainer>
 struct functor<SequenceContainer> {
 
-    template <typename UnaryFunction, typename A, typename = detail::enable_if_sequence_container<SequenceContainer>>
+    template <typename A, typename UnaryFunction, typename = detail::enable_if_sequence_container<SequenceContainer>>
     static constexpr auto fmap(SequenceContainer<A> const &input, UnaryFunction f)
         -> SequenceContainer<decltype(f(std::declval<A>()))> {
         return detail::deriving::fmap(input, f);

--- a/include/kitten/monad.h
+++ b/include/kitten/monad.h
@@ -52,7 +52,7 @@ constexpr decltype(auto) wrap(A &&value) {
  * @return a new monad mb: M[B] resulting from applying f over the wrapped value inside ma and then flattening the
  * result
  */
-template <typename UnaryFunction, template <typename...> typename M, typename A>
+template <template <typename...> typename M, typename A, typename UnaryFunction>
 constexpr decltype(auto) bind(M<A> const &input, UnaryFunction f) {
     static_assert(traits::is_monad_v<M>, "type constructor M does not have a monad instance");
     return monad<M>::bind(input, f);
@@ -62,7 +62,7 @@ constexpr decltype(auto) bind(M<A> const &input, UnaryFunction f) {
  * Infix version of bind.
  */
 
-template <typename UnaryFunction, template <typename...> typename M, typename A>
+template <template <typename...> typename M, typename A, typename UnaryFunction>
 constexpr decltype(auto) operator>>=(M<A> const &input, UnaryFunction f) {
     return bind(input, f);
 }

--- a/include/kitten/multifunctor.h
+++ b/include/kitten/multifunctor.h
@@ -28,7 +28,7 @@ inline constexpr bool is_multifunctor_v = is_multifunctor<MF>::value;
  * ..., Z2
  * @return a new multifunctor fb: F[A2, ..., Z2] resulting from applying f over the wrapped value inside fa
  */
-template <typename UnaryFunction, template <typename...> typename MF, typename... Rest>
+template <template <typename...> typename MF, typename... Rest, typename UnaryFunction>
 constexpr decltype(auto) multimap(MF<Rest...> const &input, UnaryFunction f) {
     static_assert(traits::is_multifunctor_v<MF>, "type constructor MF does not have a multifunctor instance");
     return multifunctor<MF>::multimap(input, f);
@@ -37,7 +37,7 @@ constexpr decltype(auto) multimap(MF<Rest...> const &input, UnaryFunction f) {
 /**
  * Infix version of multimap.
  */
-template <typename UnaryFunction, template <typename...> typename MF, typename A, typename... Rest>
+template <template <typename...> typename MF, typename A, typename... Rest, typename UnaryFunction>
 constexpr decltype(auto) operator||(MF<A, Rest...> const &input, UnaryFunction f) {
     return multimap(input, f);
 }

--- a/tests/function_test.cpp
+++ b/tests/function_test.cpp
@@ -12,23 +12,26 @@ using namespace types;
 
 SCENARIO("function_wrapper admits a functor instance", "[function_wrapper]") {
 
-    GIVEN("a function from double to int") {
+    GIVEN("a functor instance") {
 
-        auto double_to_int = [](double v) -> int { return static_cast<int>(v); };
+        AND_GIVEN("a function from double to int") {
 
-        AND_GIVEN("a function from int to string") {
+            auto double_to_int = [](double const v) { return static_cast<int>(v); };
 
-            auto int_to_string = [](int v) -> std::string { return std::to_string(v); };
+            AND_GIVEN("a function from int to string") {
 
-            WHEN("they are wrapped in function wrappers") {
+                auto int_to_string = [](int const v) { return std::to_string(v); };
 
-                AND_WHEN("composed together") {
+                WHEN("they are wrapped in function wrappers") {
 
-                    THEN("return the composition of a function wrapper from double to string") {
+                    AND_WHEN("fmap") {
 
-                        auto const double_to_string = fn(double_to_int) | fn(int_to_string);
+                        THEN("return the composition of a function wrapper from double to string") {
 
-                        CHECK(double_to_string(3.14) == "3"s);
+                            auto const double_to_string = fn(double_to_int) | fn(int_to_string);
+
+                            CHECK(double_to_string(3.14) == "3"s);
+                        }
                     }
                 }
             }

--- a/tests/optional_test.cpp
+++ b/tests/optional_test.cpp
@@ -51,6 +51,40 @@ SCENARIO("optional admits functor, applicative, and monad instances", "[optional
                     }
                 }
             }
+
+            AND_GIVEN("liftF") {
+
+                auto to_string_lifted = liftF<std::optional>([](auto const v) { return std::to_string(v); });
+
+                WHEN("when empty") {
+
+                    std::optional<int> const none;
+
+                    THEN("return an empty optional") {
+
+                        auto const none_of_string = to_string_lifted(none);
+
+                        static_assert(is_same_after_decaying<decltype(none_of_string), std::optional<std::string>>);
+
+                        CHECK(!none_of_string.has_value());
+                    }
+                }
+
+                WHEN("when not empty") {
+
+                    auto const some_one = std::optional{1};
+
+                    THEN("return an empty optional") {
+
+                        auto const some_one_of_string = to_string_lifted(some_one);
+
+                        static_assert(is_same_after_decaying<decltype(some_one_of_string), std::optional<std::string>>);
+
+                        CHECK(some_one_of_string.has_value());
+                        CHECK(some_one_of_string.value() == "1"s);
+                    }
+                }
+            }
         }
 
         AND_GIVEN("an applicative instance") {

--- a/tests/sequence_container_test.cpp
+++ b/tests/sequence_container_test.cpp
@@ -63,6 +63,43 @@ SCENARIO("SequenceContainer admits functor, applicative, and monad instances", "
                     }
                 }
             }
+
+            AND_GIVEN("liftF") {
+
+                auto to_string_lifted = liftF<SequenceContainer>([](auto const v) { return std::to_string(v); });
+
+                WHEN("when empty") {
+
+                    SequenceContainer<int> const empty;
+
+                    THEN("return an empty SequenceContainer") {
+
+                        auto const empty_of_strings = to_string_lifted(empty);
+
+                        static_assert(
+                            is_same_after_decaying<decltype(empty_of_strings), SequenceContainer<std::string>>);
+
+                        CHECK(empty_of_strings.empty());
+                    }
+                }
+
+                WHEN("when not empty") {
+
+                    auto const container_of_ints = SequenceContainer<int>{1, 2};
+
+                    THEN("return a non-empty SequenceContainer containing the mapped values") {
+
+                        auto const container_of_strings = to_string_lifted(container_of_ints);
+
+                        static_assert(
+                            is_same_after_decaying<decltype(container_of_strings), SequenceContainer<std::string>>);
+
+                        CHECK(container_of_strings.size() == 2);
+                        CHECK(value_at(container_of_strings, 0) == "1"s);
+                        CHECK(value_at(container_of_strings, 1) == "2"s);
+                    }
+                }
+            }
         }
 
         AND_GIVEN("an applicative instance") {


### PR DESCRIPTION
* feature: Add new combinator for functor instances: liftF
    
    That lifts a function A -> B into a function F[A] -> F[B],
    where F[_] is a functor.

* change: Take template type parameter as the last type argument
    
    Rather than the first, since it's less often to be customized during
    type-deduction.