### PR TITLE
Bind replace operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ of type `A` into a monad `X<A>`.
 Using _kitten_, one example of using a monad is:
 
 ```
-auto const maybe_name = maybe_find_person() >>= maybe_get_name; // or bind(maybe_find_person(), maybe_get_name)
+auto const maybe_name = maybe_find_person() >> maybe_get_name; // or bind(maybe_find_person(), maybe_get_name)
 ```
 
 Where `maybe_find_person` returns an `std::optional<person>`, and then the wrapped object of type `person` is fed into
@@ -220,7 +220,7 @@ Also, to simplify notation, they also come as overloaded operators that enable a
 
 - `|` as an alias for `fmap`
 - `+` as an alias for `combine`
-- `>>=` as an alias for `bind`
+- `>>` as an alias for `bind`
 - `||` as an alias for `multimap`
 
 The combinators are available conveniently in the header: `kitten/kitten.h`, or by importing each one separately. And

--- a/README.md
+++ b/README.md
@@ -209,24 +209,43 @@ set of lambda expressions, and the right overload is then selected at compile-ti
 ## kitten
 
 _kitten_ relies on the STL to provide functor, applicative, monad, and multi-functor instances for some C++ data types. Given that the data type admits
-such instances, it's then possible to use the combinators available as free functions:
+such instances, it's then possible to use the combinators available as free functions.
 
-- `fmap` for types that have functor instances
-- `combine` for types that have applicative instances
-- `bind` for types that have monad instances
-- `multimap` for types that have multi-functor instances
-
-Also, to simplify notation, they also come as overloaded operators that enable a, hopefully, nicer, infix syntax:
-
-- `|` as an alias for `fmap`
-- `+` as an alias for `combine`
-- `>>` as an alias for `bind`
-- `||` as an alias for `multimap`
+To simplify the notation, many combinators also come with overloaded operators that enable a, hopefully, nicer infix syntax
+suitable for chaining several calls.
 
 The combinators are available conveniently in the header: `kitten/kitten.h`, or by importing each one separately. And
 the main namespace is `rvarago::kitten`.
 
 Note that it's possible that a type may not admit instances for all the structures, e.g a type may have a functor but not a monad.
+
+### Functor
+
+|    Combinator     |   Infix  |
+|:-----------------:|:--------:|
+|      `fmap`       | &#x7c;   |
+|      `liftF`      |          |
+
+### Multi-functor
+
+|    Combinator     |      Infix    |
+|:-----------------:|:-------------:|
+|      `multimap`   |  &#x7c;&#x7c; |
+
+### Applicative
+
+|    Combinator     |      Infix    |
+|:-----------------:|:-------------:|
+|      `pure`       |               |
+|      `combine`    |        +      |
+
+
+### Monad
+
+|    Combinator     |      Infix    |
+|:-----------------:|:-------------:|
+|      `wrap`       |               |
+|      `bind`       |        >>     |
 
 ### Adapters
 

--- a/include/kitten/monad.h
+++ b/include/kitten/monad.h
@@ -16,9 +16,9 @@ namespace rvarago::kitten {
  *
  * Laws:
  *
- * - Left identity: return a >>= f == f a
- * - Right identity: m >>= return == m
- * - Associativity: (m >>= f) >>= g == m >>= (\x -> f x >>= g)
+ * - Left identity: return a >> f == f a
+ * - Right identity: m >> return == m
+ * - Associativity: (m >> f) >> g == m >> (\x -> f x >> g)
  */
 template <template <typename...> typename M, typename = void>
 struct monad;
@@ -63,7 +63,7 @@ constexpr decltype(auto) bind(M<A> const &input, UnaryFunction f) {
  * Infix version of bind.
  */
 template <template <typename...> typename M, typename A, typename UnaryFunction>
-constexpr decltype(auto) operator>>=(M<A> const &input, UnaryFunction f) {
+constexpr decltype(auto) operator>>(M<A> const &input, UnaryFunction f) {
     return bind(input, f);
 }
 

--- a/tests/optional_test.cpp
+++ b/tests/optional_test.cpp
@@ -22,7 +22,7 @@ SCENARIO("optional admits functor, applicative, and monad instances", "[optional
 
                 auto to_string = [](auto const v) { return std::to_string(v); };
 
-                WHEN("when empty") {
+                WHEN("empty") {
 
                     std::optional<int> const none;
 
@@ -36,7 +36,7 @@ SCENARIO("optional admits functor, applicative, and monad instances", "[optional
                     }
                 }
 
-                WHEN("when not empty") {
+                WHEN("not empty") {
 
                     auto const some_one = std::optional{1};
 
@@ -56,7 +56,7 @@ SCENARIO("optional admits functor, applicative, and monad instances", "[optional
 
                 auto to_string_lifted = liftF<std::optional>([](auto const v) { return std::to_string(v); });
 
-                WHEN("when empty") {
+                WHEN("empty") {
 
                     std::optional<int> const none;
 
@@ -70,7 +70,7 @@ SCENARIO("optional admits functor, applicative, and monad instances", "[optional
                     }
                 }
 
-                WHEN("when not empty") {
+                WHEN("not empty") {
 
                     auto const some_one = std::optional{1};
 
@@ -106,7 +106,7 @@ SCENARIO("optional admits functor, applicative, and monad instances", "[optional
 
                 auto to_product_as_string = [](auto const &a, auto const &b) { return std::to_string(a * b); };
 
-                WHEN("when empty") {
+                WHEN("empty") {
 
                     std::optional<int> const none;
 
@@ -121,7 +121,7 @@ SCENARIO("optional admits functor, applicative, and monad instances", "[optional
                     }
                 }
 
-                WHEN("when not empty") {
+                WHEN("not empty") {
 
                     auto const some_two = std::optional{2};
 
@@ -157,33 +157,34 @@ SCENARIO("optional admits functor, applicative, and monad instances", "[optional
             AND_GIVEN("bind") {
 
                 auto to_optional_string = [](auto v) { return std::optional{std::to_string(v)}; };
+                auto to_optional_int = [](auto v) { return std::optional{std::stoi(v)}; };
 
-                WHEN("when empty") {
+                WHEN("empty") {
 
                     std::optional<int> const none;
 
                     THEN("return an empty optional") {
 
-                        auto const none_of_string = none >>= to_optional_string;
+                        auto const none_of_string = none >> to_optional_string >> to_optional_int;
 
-                        static_assert(is_same_after_decaying<decltype(none_of_string), std::optional<std::string>>);
+                        static_assert(is_same_after_decaying<decltype(none_of_string), std::optional<int>>);
 
                         CHECK(!none_of_string.has_value());
                     }
                 }
 
-                WHEN("when not empty") {
+                WHEN("not empty") {
 
                     auto const some_one = std::optional{1};
 
                     THEN("return a non-empty optional containing the bound value") {
 
-                        auto const some_one_of_string = some_one >>= to_optional_string;
+                        auto const some_one_of_string = some_one >> to_optional_string >> to_optional_int;
 
-                        static_assert(is_same_after_decaying<decltype(some_one_of_string), std::optional<std::string>>);
+                        static_assert(is_same_after_decaying<decltype(some_one_of_string), std::optional<int>>);
 
                         CHECK(some_one_of_string.has_value());
-                        CHECK(some_one_of_string.value() == "1"s);
+                        CHECK(some_one_of_string.value() == 1);
                     }
                 }
             }

--- a/tests/sequence_container_test.cpp
+++ b/tests/sequence_container_test.cpp
@@ -31,7 +31,7 @@ SCENARIO("SequenceContainer admits functor, applicative, and monad instances", "
 
                 auto to_string = [](auto const v) { return std::to_string(v); };
 
-                WHEN("when empty") {
+                WHEN("empty") {
 
                     SequenceContainer<int> const empty;
 
@@ -46,7 +46,7 @@ SCENARIO("SequenceContainer admits functor, applicative, and monad instances", "
                     }
                 }
 
-                WHEN("when not empty") {
+                WHEN("not empty") {
 
                     auto const container_of_ints = SequenceContainer<int>{1, 2};
 
@@ -68,7 +68,7 @@ SCENARIO("SequenceContainer admits functor, applicative, and monad instances", "
 
                 auto to_string_lifted = liftF<SequenceContainer>([](auto const v) { return std::to_string(v); });
 
-                WHEN("when empty") {
+                WHEN("empty") {
 
                     SequenceContainer<int> const empty;
 
@@ -83,7 +83,7 @@ SCENARIO("SequenceContainer admits functor, applicative, and monad instances", "
                     }
                 }
 
-                WHEN("when not empty") {
+                WHEN("not empty") {
 
                     auto const container_of_ints = SequenceContainer<int>{1, 2};
 
@@ -123,7 +123,7 @@ SCENARIO("SequenceContainer admits functor, applicative, and monad instances", "
                     return std::to_string(std::stoi(a) * b);
                 };
 
-                WHEN("when empty") {
+                WHEN("empty") {
 
                     SequenceContainer<std::string> const empty_of_string;
 
@@ -140,7 +140,7 @@ SCENARIO("SequenceContainer admits functor, applicative, and monad instances", "
                     }
                 }
 
-                WHEN("when not empty") {
+                WHEN("not empty") {
 
                     auto const first_container_of_string = SequenceContainer<std::string>{"2", "3"};
 
@@ -184,13 +184,13 @@ SCENARIO("SequenceContainer admits functor, applicative, and monad instances", "
                     return SequenceContainer<std::string>{std::to_string(v), std::to_string(v)};
                 };
 
-                WHEN("when empty") {
+                WHEN("empty") {
 
                     SequenceContainer<int> const empty;
 
                     THEN("return an empty SequenceContainer") {
 
-                        auto const empty_of_string = SequenceContainer<int>{} >>= to_SequenceContainer_string;
+                        auto const empty_of_string = SequenceContainer<int>{} >> to_SequenceContainer_string;
 
                         static_assert(
                             is_same_after_decaying<decltype(empty_of_string), SequenceContainer<std::string>>);
@@ -199,13 +199,13 @@ SCENARIO("SequenceContainer admits functor, applicative, and monad instances", "
                     }
                 }
 
-                WHEN("when not empty") {
+                WHEN("not empty") {
 
                     auto const container = SequenceContainer<int>{1, 2};
 
                     THEN("return a non-empty SequenceContainer containing the bound value") {
 
-                        auto const container_of_string = container >>= to_SequenceContainer_string;
+                        auto const container_of_string = container >> to_SequenceContainer_string;
 
                         static_assert(
                             is_same_after_decaying<decltype(container_of_string), SequenceContainer<std::string>>);


### PR DESCRIPTION
*  docs: List all combinators provided by each abstraction
    
    Using a tabular format that makes it easier to understand.

* change: Use operator>> rather than operator>>= for infix bind
    
    Because the latter is right-associative, therefore it does not play
    nicely with multiple chaining.
