### PR TITLE
feature: Applicative: Add new combinator: liftA2

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,9 @@ auto const maybe_six_as_string = std::tuple{maybe_two, maybe_three} + [](auto co
 };
 ```
 
+Another helpful function provided by applicatives is  `liftA2`, which generalizes `liftF` for binaries functions of kind
+`w: A -> B -> C`, lifting it into another function `z: X[A] -> X[B] -> X[C]`, where `X[T]` is some applicative.
+
 ### Monads
 
 What happens if `f` and `g` are both effectul functions: `f: A -> X<B>` and `g: B -> X<C>`. How can
@@ -238,6 +241,7 @@ Note that it's possible that a type may not admit instances for all the structur
 |:-----------------:|:-------------:|
 |      `pure`       |               |
 |      `combine`    |        +      |
+|      `liftA2`     |               |
 
 
 ### Monad

--- a/include/kitten/applicative.h
+++ b/include/kitten/applicative.h
@@ -47,8 +47,8 @@ constexpr decltype(auto) pure(A &&value) {
  * @return a new applicative apc: AP[C] resulting from wrapping the application of f over the wrapped value inside apa
  * and apb
  */
-template <template <typename...> typename AP, typename A, typename B, typename BinaryFunction>
-constexpr decltype(auto) combine(AP<A> const &first, AP<B> const &second, BinaryFunction f) {
+template <template <typename...> typename AP, typename A, typename B, typename BinaryFunction = std::plus<>>
+constexpr decltype(auto) combine(AP<A> const &first, AP<B> const &second, BinaryFunction f = BinaryFunction{}) {
     static_assert(traits::is_applicative_v<AP>, "type constructor AP does not have an applicative instance");
     return applicative<AP>::combine(first, second, f);
 }
@@ -66,7 +66,7 @@ constexpr decltype(auto) operator+(std::tuple<AP<A>, AP<B>> const &input, Binary
  */
 template <template <typename...> typename AP, typename A, typename B>
 constexpr decltype(auto) operator+(AP<A> const &first, AP<B> const &second) {
-    return combine(first, second, std::plus{});
+    return combine(first, second);
 }
 
 }

--- a/include/kitten/applicative.h
+++ b/include/kitten/applicative.h
@@ -69,6 +69,17 @@ constexpr decltype(auto) operator+(AP<A> const &first, AP<B> const &second) {
     return combine(first, second);
 }
 
+/**
+ * lifts a binary function f: A -> B -> C into an applicative context fap: AP[A] -> AP[B] -> AP[C].
+ *
+ * @param f binary function f: A -> B -> C to be lifted into the applicative AP[T] context.
+ * @return the lifted version of f that operates on applicatives.
+ */
+template <template <typename...> typename AP, typename BinaryFunction>
+constexpr decltype(auto) liftA2(BinaryFunction f) {
+    return [f](auto const &first, auto const &second) { return combine<AP>(first, second, f); };
+}
+
 }
 
 #endif

--- a/include/kitten/instances/optional.h
+++ b/include/kitten/instances/optional.h
@@ -17,7 +17,7 @@ struct monad<std::optional> {
 
     template <typename A, typename UnaryFunction>
     static constexpr auto bind(std::optional<A> const &input, UnaryFunction f) -> decltype(f(std::declval<A>())) {
-        if (!input) {
+        if (!input.has_value()) {
             return std::nullopt;
         }
         return f(*input);

--- a/tests/optional_test.cpp
+++ b/tests/optional_test.cpp
@@ -4,6 +4,7 @@
 #include <string>
 
 #include "utils.h"
+#include <functional>
 
 namespace {
 
@@ -91,7 +92,7 @@ SCENARIO("optional admits functor, applicative, and monad instances", "[optional
 
             AND_GIVEN("pure") {
 
-                THEN("lift into a non-empty optioanl") {
+                THEN("lift into a non-empty optional") {
 
                     auto const some_one = pure<std::optional>("1"s);
 
@@ -134,6 +135,46 @@ SCENARIO("optional admits functor, applicative, and monad instances", "[optional
 
                         CHECK(product_of_string.has_value());
                         CHECK(product_of_string.value() == "6"s);
+                    }
+                }
+            }
+
+            AND_GIVEN("liftA2") {
+
+                auto const lifted_plus = liftA2<std::optional>(std::plus<int>{});
+
+                WHEN("any is empty") {
+
+                    THEN("the lifted function that adds to integers into one should return an empty optional") {
+
+                        std::optional<int> const none = std::nullopt;
+                        auto const some = std::optional{42};
+
+                        auto const left_sum = lifted_plus(none, some);
+                        auto const right_sum = lifted_plus(some, none);
+
+                        static_assert(is_same_after_decaying<decltype(left_sum), std::optional<int>>);
+                        static_assert(is_same_after_decaying<decltype(right_sum), std::optional<int>>);
+
+                        CHECK(!left_sum.has_value());
+                        CHECK(!right_sum.has_value());
+                    }
+                }
+
+                WHEN("both are not empty") {
+
+                    THEN("the lifted function that adds to integers into one should return a filled optional "
+                         "containing the sum") {
+
+                        auto const some_1 = std::optional{1};
+                        auto const some_2 = std::optional{2};
+
+                        auto const sum = lifted_plus(some_1, some_2);
+
+                        static_assert(is_same_after_decaying<decltype(sum), std::optional<int>>);
+
+                        CHECK(sum.has_value());
+                        CHECK(sum.value() == 3);
                     }
                 }
             }


### PR DESCRIPTION
* feature: Applicative: Add new combinator: liftA2
    
    liftA2 lifts a binary function f: A -> B -> C into an applicative
    context fap: AP[A] -> AP[B] -> AP[C].

* feature: Applicative: Set std::plus as default operation for combine

* refactor: Use has_value() to check for empty std::optional
    
    Since it shows up more clearly when reading.