### PR TITLE
Fixes to catch2 includes and building on macOS

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,8 +10,23 @@ add_executable(${PROJECT_NAME}
         variant_test.cpp
 )
 
-if (${CMAKE_CXX_COMPILER_ID} MATCHES "GNU|Clang")
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+if (CMAKE_CXX_COMPILER_ID MATCHES "GNU")
     target_compile_options(${PROJECT_NAME}
+            PRIVATE
+                -std=gnu++17
+    )
+else()
+    target_compile_options(${PROJECT_NAME}
+            PRIVATE
+                -std=c++17
+    )
+endif()
+
+if (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+    add_compile_options(${PROJECT_NAME}
             PRIVATE
                 -Wall -Wextra -Werror -ansi -pedantic
     )

--- a/tests/function_test.cpp
+++ b/tests/function_test.cpp
@@ -1,4 +1,4 @@
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 
 #include <kitten/instances/function.h>
 #include <string>

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -1,3 +1,3 @@
 #define CATCH_CONFIG_MAIN
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -1,3 +1,5 @@
 #define CATCH_CONFIG_MAIN
 
 #include <catch2/catch_all.hpp>
+
+int main() { return 0; }

--- a/tests/optional_test.cpp
+++ b/tests/optional_test.cpp
@@ -1,4 +1,4 @@
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 
 #include <kitten/instances/optional.h>
 #include <string>

--- a/tests/sequence_container_test.cpp
+++ b/tests/sequence_container_test.cpp
@@ -1,4 +1,4 @@
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 
 #include "utils.h"
 #include <functional>

--- a/tests/variant_test.cpp
+++ b/tests/variant_test.cpp
@@ -1,4 +1,4 @@
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 
 #include <optional>
 #include <string>


### PR DESCRIPTION
This PR mirrors the one to `absent`: https://github.com/rvarago/absent/pull/71

Fixes includes, missing `_main` and adds needed compiler cxxflags.